### PR TITLE
feat: Support creating api_keys in subuser accounts

### DIFF
--- a/sendgrid/resource_sendgrid_api_key.go
+++ b/sendgrid/resource_sendgrid_api_key.go
@@ -60,6 +60,11 @@ func resourceSendgridAPIKey() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 			},
+			"sub_user_on_behalf_of": {
+				Type:        schema.TypeString,
+				Description: "The subuser's username. The API call is made on behalf of the subuser account.",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -79,6 +84,10 @@ func resourceSendgridAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m
 
 	c := m.(*sendgrid.Client)
 	name := d.Get("name").(string)
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if len(onBehalfOf) > 0 {
+		c.OnBehalfOf = onBehalfOf
+	}
 
 	for _, scope := range d.Get("scopes").(*schema.Set).List() {
 		scopes = append(scopes, scope.(string))
@@ -108,6 +117,11 @@ func resourceSendgridAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceSendgridAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*sendgrid.Client)
 
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if len(onBehalfOf) > 0 {
+		c.OnBehalfOf = onBehalfOf
+	}
+
 	apiKey, err := c.ReadAPIKey(ctx, d.Id())
 	if err.Err != nil {
 		return diag.FromErr(err.Err)
@@ -131,6 +145,11 @@ func hasDiff(o, n interface{}) bool {
 
 func resourceSendgridAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*sendgrid.Client)
+
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if len(onBehalfOf) > 0 {
+		c.OnBehalfOf = onBehalfOf
+	}
 
 	a := sendgrid.APIKey{
 		ID:   d.Id(),
@@ -162,6 +181,11 @@ func resourceSendgridAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceSendgridAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*sendgrid.Client)
+
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if len(onBehalfOf) > 0 {
+		c.OnBehalfOf = onBehalfOf
+	}
 
 	_, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
 		return c.DeleteAPIKey(ctx, d.Id())


### PR DESCRIPTION
Add optional property `sub_user_on_behalf_of` to `sendgrid_api_key` resource to create api keys in sub user accounts.  Implements #58 . 