### PR TITLE
fix: parse webhook updates

### DIFF
--- a/sdk/parse_webhook.go
+++ b/sdk/parse_webhook.go
@@ -84,10 +84,10 @@ func (c *Client) ReadParseWebhook(ctx context.Context, hostname string) (*ParseW
 		}
 	}
 
-	respBody, _, err := c.Get(ctx, "GET", "/user/webhooks/parse/settings/"+hostname)
+	respBody, statusCode, err := c.Get(ctx, "GET", "/user/webhooks/parse/settings/"+hostname)
 	if err != nil {
 		return nil, RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: statusCode,
 			Err:        err,
 		}
 	}
@@ -109,7 +109,7 @@ func (c *Client) UpdateParseWebhook(ctx context.Context, hostname string, spamCh
 	t.SendRaw = sendRaw
 	t.SecurityPolicy = securityPolicy
 
-	_, _, err := c.Post(ctx, "PUT", "/user/webhooks/parse/settings/"+hostname, t)
+	_, _, err := c.Post(ctx, "PATCH", "/user/webhooks/parse/settings/"+hostname, t)
 	if err != nil {
 		return RequestError{
 			StatusCode: http.StatusInternalServerError,

--- a/sendgrid/resource_sendgrid_parse_webhook.go
+++ b/sendgrid/resource_sendgrid_parse_webhook.go
@@ -21,6 +21,7 @@ package sendgrid
 
 import (
 	"context"
+	"net/http"
 
 	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -117,6 +118,11 @@ func resourceSendgridParseWebhookRead(ctx context.Context, d *schema.ResourceDat
 
 	webhook, err := c.ReadParseWebhook(ctx, d.Id())
 	if err.Err != nil {
+		if err.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(err.Err)
 	}
 

--- a/sendgrid/resource_sendgrid_parse_webhook_test.go
+++ b/sendgrid/resource_sendgrid_parse_webhook_test.go
@@ -29,6 +29,12 @@ func TestAccSendgridParseWebhookBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "spam_check", "true"),
 				),
 			},
+			// Import test
+			{
+				ResourceName:      "sendgrid_parse_webhook.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -78,6 +84,37 @@ func TestAccSendgridParseWebhookUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSendgridParseWebhookExists("sendgrid_parse_webhook.test"),
 					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "url", urlUpdated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSendgridParseWebhookUpdateInPlace(t *testing.T) {
+	hostname := "parse-inplace-" + acctest.RandString(10) + ".example.com"
+	url := "https://inplace-" + acctest.RandString(10) + ".com/parse"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSendgridParseWebhookConfigBasic(hostname, url),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSendgridParseWebhookExists("sendgrid_parse_webhook.test"),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "spam_check", "true"),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "send_raw", "false"),
+				),
+			},
+			{
+				Config: testAccCheckSendgridParseWebhookConfigUpdatedFields(hostname, url),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSendgridParseWebhookExists("sendgrid_parse_webhook.test"),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "hostname", hostname),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "url", url),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "spam_check", "false"),
+					resource.TestCheckResourceAttr("sendgrid_parse_webhook.test", "send_raw", "true"),
 				),
 			},
 		},
@@ -152,6 +189,17 @@ resource "sendgrid_parse_webhook" "test" {
 	url        = "%s"
 	spam_check = true
 	send_raw   = false
+}
+`, hostname, url)
+}
+
+func testAccCheckSendgridParseWebhookConfigUpdatedFields(hostname, url string) string {
+	return fmt.Sprintf(`
+resource "sendgrid_parse_webhook" "test" {
+	hostname   = "%s"
+	url        = "%s"
+	spam_check = false
+	send_raw   = true
 }
 `, hostname, url)
 }


### PR DESCRIPTION
## Description
Fix parse webhook import by correcting the HTTP method used for updates (PUT → PATCH) and improving error handling in the Read path to properly handle 404 responses.
When importing a parse webhook via terraform import and then running terraform apply, the subsequent update operation failed with HTTP 404: 404 page not found because UpdateParseWebhook used PUT, but the SendGrid API only supports PATCH for /user/webhooks/parse/settings/{hostname}. This bug was latent because no existing test exercised the actual update code path — the "update" test only changed ForceNew fields, triggering destroy+recreate instead.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Test improvements
- [ ] Chore (dependency updates, tooling, etc.)

## Related Issues
Fixes https://github.com/arslanbekov/terraform-provider-sendgrid/issues/86
## Changes Made
- sdk/parse_webhook.go: Changed UpdateParseWebhook HTTP method from PUT to PATCH — root cause of the 404 during post-import apply
- sdk/parse_webhook.go: Fixed ReadParseWebhook to preserve the actual HTTP status code from c.Get instead of hardcoding http.StatusInternalServerError, enabling callers to distinguish 404 from other errors
- sendgrid/resource_sendgrid_parse_webhook.go: Added 404 handling in resourceSendgridParseWebhookRead — on http.StatusNotFound, calls d.SetId("") and returns nil (matching the pattern in resource_sendgrid_event_webhook.go) instead of returning a hard error
- sendgrid/resource_sendgrid_parse_webhook_test.go: Added ImportState test step to TestAccSendgridParseWebhookBasic to verify import round-trip
- sendgrid/resource_sendgrid_parse_webhook_test.go: Added TestAccSendgridParseWebhookUpdateInPlace — a new test that changes non-ForceNew fields (spam_check, send_raw) on an existing resource, which actually exercises the Update/PATCH code path
## Testing
## Unit Tests
- [ ] I have added unit tests for my changes
- [x] All unit tests pass locally (make test)
### Acceptance Tests
- [x] I have added/updated acceptance tests (make testacc)
- [ ] All acceptance tests pass with a real SendGrid account
- [x] Tests include Create, Read, Update, and Delete operations (if applicable)

###Manual Testing
# Import an existing parse webhook, then apply to update security policy
resource "sendgrid_parse_webhook" "agent" {
  hostname                   = "agent.rogodata.com"
  url                        = "https://sendgrid-inbound-parse-446668253149.us-central1.run.app/inbound"
  spam_check                 = true
  send_raw                   = false
  webhook_security_policy_id = sendgrid_webhook_security_policy.agent.id
}
terraform import sendgrid_parse_webhook.agent agent.rogodata.com
terraform apply

**Test Results:**
# go build and go vet pass cleanly
$ go build ./...
$ go vet ./...
## Documentation
- [ ] I have updated the documentation in docs/
- [ ] I have added examples to examples/resources/
- [ ] I have updated the CHANGELOG.md
- [x] I have added/updated code comments where necessary
- [ ] All exported functions have godoc comments
## Checklist
- [x] My code follows the project's coding standards (CONTRIBUTING.md#coding-standards)
- [x] I have run make fmt to format the code
- [x] I have run make lint and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for any breaking changes
- [x] My commit messages follow the Conventional Commits (https://www.conventionalcommits.org/) format
## Breaking Changes
** Is this a breaking change? No**
## Screenshots (if applicable)
N/A
## Additional Context
The root cause was that UpdateParseWebhook in sdk/parse_webhook.go used PUT while the SendGrid API expects PATCH for parse webhook updates. This was never caught because TestAccSendgridParseWebhookUpdate only changed the url field, which is marked ForceNew: true — Terraform handled that as destroy+recreate, never calling resourceSendgridParseWebhookUpdate. The new TestAccSendgridParseWebhookUpdateInPlace test closes this gap by modifying spam_check and send_raw (non-ForceNew fields).
## Reviewer Notes
- The PUT → PATCH fix in sdk/parse_webhook.go:112 is the critical one-line change that resolves the 404.
- The 404 handling in Read and status code preservation in the SDK are defensive improvements that align this resource with the pattern already used by sendgrid_event_webhook.
- The dead resourceSendgridParseWebhookImportState function (which used Plugin Framework types in an SDKv2 provider) was already removed prior to this PR.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Mozilla Public License 2.0.