### PR TITLE
fix panic error. streamline logging

### DIFF
--- a/sdk/domain_authentication.go
+++ b/sdk/domain_authentication.go
@@ -154,7 +154,7 @@ func (c *Client) ValidateDomainAuthentication(ctx context.Context, id string) Re
 		}
 	}
 
-	respBody, statusCode, err := c.Post(ctx, "POST", "/whitelabel/domains/"+id+"/validate", nil)
+	respBody, statusCode, err := c.Post(ctx, "POST", "/whitelabel/domains/"+id+"/validate", map[string]interface{}{})
 	if err != nil || statusCode != 200 {
 		return RequestError{
 			StatusCode: statusCode,
@@ -173,7 +173,7 @@ func (c *Client) ValidateDomainAuthentication(ctx context.Context, id string) Re
 	if valid, ok := res["valid"].(bool); ok && !valid {
 		return RequestError{
 			StatusCode: http.StatusInternalServerError,
-			Err:        ErrDomainAuthenticationValidationFailed,
+			Err:        fmt.Errorf("%w: %s", ErrDomainAuthenticationValidationFailed, respBody),
 		}
 	}
 

--- a/sdk/domain_authentication_test.go
+++ b/sdk/domain_authentication_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
@@ -176,8 +177,11 @@ func TestClient_ValidateDomainAuthentication_ShouldErrorForResponseBodySayingVal
 		t.Errorf("ValidateDomainAuthentication() got = %v, want %v", requestError, "error")
 	}
 	errMsg := sendgrid.ErrDomainAuthenticationValidationFailed.Error()
-	if requestError.Err.Error() != errMsg {
-		t.Errorf("ValidateDomainAuthentication() got = %v, want %v", requestError.Err.Error(),
+	if !errors.Is(requestError.Err, sendgrid.ErrDomainAuthenticationValidationFailed) {
+		t.Errorf("ValidateDomainAuthentication() got = %v, want wrapped validation failed error", requestError.Err)
+	}
+	if !strings.Contains(requestError.Err.Error(), errMsg) {
+		t.Errorf("ValidateDomainAuthentication() got = %v, want message containing %v", requestError.Err.Error(),
 			errMsg)
 	}
 }

--- a/sendgrid/resource_sendgrid_domain_authentication_validation.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation.go
@@ -13,7 +13,7 @@ package sendgrid
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -37,6 +37,12 @@ func resourceSendgridDomainAuthenticationValidation() *schema.Resource { //nolin
 				Required:    true,
 				ForceNew:    true,
 			},
+			"sub_user_on_behalf_of": {
+				Type:        schema.TypeString,
+				Description: "The subuser username for on-behalf-of API calls.",
+				Optional:    true,
+				ForceNew:    true,
+			},
 
 			"valid": {
 				Type:        schema.TypeBool,
@@ -56,18 +62,28 @@ func resourceSendgridDomainAuthenticationValidationCreate(
 }
 
 func validateDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*sendgrid.Client)
+	config := m.(*Config)
+	c := config.NewClient("")
 
-	if err := c.ValidateDomainAuthentication(ctx, d.Get("domain_authentication_id").(string)); err.Err != nil || err.StatusCode != 200 {
-		if err.Err != nil {
-			return diag.FromErr(err.Err)
-		}
-		return diag.Errorf("unable to validate domain DNS configuration")
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if onBehalfOf != "" {
+		c.OnBehalfOf = onBehalfOf
 	}
 
-	d.SetId(d.Get("domain_authentication_id").(string))
+	domainID := d.Get("domain_authentication_id").(string)
 
-	return resourceSendgridDomainAuthenticationValidationRead(ctx, d, m)
+	validateErr := c.ValidateDomainAuthentication(ctx, domainID)
+	if validateErr.Err != nil {
+		return diag.FromErr(validateErr.Err)
+	}
+
+	if err := d.Set("valid", true); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(domainID)
+
+	return nil
 }
 
 func resourceSendgridDomainAuthenticationValidationRead( //nolint:funlen,cyclop
@@ -75,18 +91,33 @@ func resourceSendgridDomainAuthenticationValidationRead( //nolint:funlen,cyclop
 	d *schema.ResourceData,
 	m interface{},
 ) diag.Diagnostics {
-	c := m.(*sendgrid.Client)
+	config := m.(*Config)
+	c := config.NewClient("")
 
-	auth, err := c.ReadDomainAuthentication(ctx, d.Get("domain_authentication_id").(string))
-	if err.Err != nil {
+	onBehalfOf := d.Get("sub_user_on_behalf_of").(string)
+	if onBehalfOf != "" {
+		c.OnBehalfOf = onBehalfOf
+	}
+
+	domainID := d.Get("domain_authentication_id").(string)
+	if d.Id() != "" {
+		domainID = d.Id()
+	}
+
+	if _, err := c.ReadDomainAuthentication(ctx, domainID); err.Err != nil {
 		return diag.FromErr(err.Err)
 	}
 
-	if err := d.Set("valid", auth.Valid); err != nil {
+	validateErr := c.ValidateDomainAuthentication(ctx, domainID)
+	if validateErr.Err != nil && !errors.Is(validateErr.Err, sendgrid.ErrDomainAuthenticationValidationFailed) {
+		return diag.FromErr(validateErr.Err)
+	}
+
+	if err := d.Set("valid", validateErr.Err == nil); err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprint(auth.ID))
+	d.SetId(domainID)
 	return nil
 }
 

--- a/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
+	provider "github.com/arslanbekov/terraform-provider-sendgrid/sendgrid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -47,7 +47,8 @@ resource "sendgrid_domain_authentication_validation" "this" {
 }
 
 func testAccCheckSendgridDomainAuthenticationValidationDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*sendgrid.Client)
+	config := testAccProvider.Meta().(*provider.Config)
+	c := config.NewClient("")
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "sendgrid_domain_authentication_validation" {


### PR DESCRIPTION
## Description
When running domain validation we got an error:
```
Stack trace from the terraform-provider-sendgrid_v2.1.2_x5 plugin:

panic: interface conversion: interface {} is *sendgrid.Config, not *sendgrid.Client

goroutine 162 [running]:
github.com/arslanbekov/terraform-provider-sendgrid/sendgrid.resourceSendgridDomainAuthenticationValidationRead({0xf32c88?, 0xc000494070?}, 0x1176592e000?, {0xcacca0?, 0xc00013f8c0?})
        github.com/arslanbekov/terraform-provider-sendgrid/sendgrid/resource_sendgrid_domain_authentication_validation.go:78 +0x1f7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0001d5400, {0xf32be0, 0xc0004128d0}, 0xc0005415f0, {0xcacca0, 0xc00013f8c0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:866 +0x119
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0001d5400, {0xf32be0, 0xc0004128d0}, 0xc0006d6ea0, {0xcacca0, 0xc00013f8c0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:1162 +0x52a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00037e510, {0xf32be0?, 0xc000412810?}, 0xc00042e5f0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/grpc_provider.go:915 +0xb6d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc0002734a0, {0xf32be0?, 0xc0002e1680?}, 0xc00018b5e0)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/tf5server/server.go:862 +0x2f3
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0xdc9800, 0xc0002734a0}, {0xf32be0, 0xc0002e1680}, 0xc0005a6e80, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:753 +0x1a9
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000274200, {0xf32be0, 0xc0002e15f0}, 0xc00050fda0, 0xc00038c5d0, 0x1551c78, 0x0)
        google.golang.org/grpc@v1.75.1/server.go:1431 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc000274200, {0xf334c8, 0xc0004aa000}, 0xc00050fda0)
        google.golang.org/grpc@v1.75.1/server.go:1842 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.75.1/server.go:1061 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 23
        google.golang.org/grpc@v1.75.1/server.go:1072 +0x11d

```
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (dependency updates, tooling, etc.)

## Changes Made

- Fixed bug by changing config settings
- add on-behalf-of for domain validation
- put sendgrid error in error handling for beter overview

## Testing
Run terraform test against sendgrid domain

### Unit Tests

- [x] I have added unit tests for my changes
- [x] All unit tests pass locally (`make test`)

### Acceptance Tests

- [x] I have added/updated acceptance tests (`make testacc`)
- [x] All acceptance tests pass with a real SendGrid account
- [x] Tests include Create, Read, Update, and Delete operations (if applicable)

### Manual Testing
Run terraform test against sendgrid domain

```hcl

resource "sendgrid_domain_authentication" "domains" {
  domain                = "my.test.domain"
  is_default            = false
  automatic_security    = true
  custom_spf            = false
  sub_user_on_behalf_of = "test-user"
  
}

resource "sendgrid_domain_authentication_validation" "this" {
  domain_authentication_id = sendgrid_domain_authentication.domains.id
  sub_user_on_behalf_of    = "test-user"
}
```

**Test Results:**

```
Terraform will perform the following actions:

  # sendgrid_domain_authentication.domains will be created
  + resource "sendgrid_domain_authentication" "domains" {
      + automatic_security    = true
      + custom_spf            = false
      + dns                   = (known after apply)
      + domain                = "rchrd.be"
      + id                    = (known after apply)
      + ips                   = (known after apply)
      + is_default            = false
      + sub_user_on_behalf_of = "stg-test-01"
      + subdomain             = (known after apply)
      + username              = (known after apply)
      + valid                 = (known after apply)
    }

  # sendgrid_domain_authentication_validation.this will be created
  + resource "sendgrid_domain_authentication_validation" "this" {
      + domain_authentication_id = (known after apply)
      + id                       = (known after apply)
      + sub_user_on_behalf_of    = "stg-test-01"
      + valid                    = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

## Documentation

- [x] I have updated the documentation in `docs/`
- [x] I have added examples to `examples/resources/`
- [x] I have updated the CHANGELOG.md
- [x] I have added/updated code comments where necessary
- [x] All exported functions have godoc comments

## Checklist

- [x] My code follows the project's [coding standards](CONTRIBUTING.md#coding-standards)
- [x] I have run `make fmt` to format the code
- [x] I have run `make lint` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for any breaking changes
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Mozilla Public License 2.0.
