### PR TITLE
fix: domain authentication validation correctness issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Run Unit Tests with Coverage
         run: |
-          # Run only non-acceptance tests (TestProvider and TestProvider_impl) with coverage
-          go test -v ./sendgrid/ -run '^TestProvider' -timeout=30s -coverprofile=coverage.txt -covermode=atomic
+          # Run all unit tests across both packages (acceptance tests auto-skip without TF_ACC)
+          go test -v ./... -timeout=60s -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6

--- a/sdk/domain_authentication.go
+++ b/sdk/domain_authentication.go
@@ -106,10 +106,10 @@ func (c *Client) ReadDomainAuthentication(ctx context.Context, id string) (*Doma
 		}
 	}
 
-	respBody, _, err := c.Get(ctx, "GET", "/whitelabel/domains/"+id)
+	respBody, statusCode, err := c.Get(ctx, "GET", "/whitelabel/domains/"+id)
 	if err != nil {
 		return nil, RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: statusCode,
 			Err:        err,
 		}
 	}
@@ -155,10 +155,17 @@ func (c *Client) ValidateDomainAuthentication(ctx context.Context, id string) Re
 	}
 
 	respBody, statusCode, err := c.Post(ctx, "POST", "/whitelabel/domains/"+id+"/validate", map[string]interface{}{})
-	if err != nil || statusCode != 200 {
+	if err != nil {
 		return RequestError{
 			StatusCode: statusCode,
 			Err:        err,
+		}
+	}
+
+	if statusCode != http.StatusOK {
+		return RequestError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("unexpected status code %d: %s", statusCode, respBody),
 		}
 	}
 

--- a/sdk/domain_authentication_test.go
+++ b/sdk/domain_authentication_test.go
@@ -127,6 +127,59 @@ func setup() func() {
 		server.Close()
 	}
 }
+func TestClient_ReadDomainAuthentication_Success(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/whitelabel/domains/123", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":123,"domain":"example.com","valid":true}`))
+	})
+	client := sendgrid.NewClient("api-key", server.URL, "")
+
+	auth, reqErr := client.ReadDomainAuthentication(context.Background(), "123")
+
+	if reqErr.Err != nil {
+		t.Fatalf("ReadDomainAuthentication() unexpected error: %v", reqErr.Err)
+	}
+	if auth.ID != 123 {
+		t.Errorf("ReadDomainAuthentication() ID = %d, want 123", auth.ID)
+	}
+	if !auth.Valid {
+		t.Error("ReadDomainAuthentication() Valid = false, want true")
+	}
+}
+
+func TestClient_ReadDomainAuthentication_NotFound(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/whitelabel/domains/999", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"not found"}]}`))
+	})
+	client := sendgrid.NewClient("api-key", server.URL, "")
+
+	_, reqErr := client.ReadDomainAuthentication(context.Background(), "999")
+
+	if reqErr.Err == nil {
+		t.Fatal("ReadDomainAuthentication() expected error for 404, got nil")
+	}
+	if reqErr.StatusCode != http.StatusNotFound {
+		t.Errorf("ReadDomainAuthentication() StatusCode = %d, want %d", reqErr.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestClient_ReadDomainAuthentication_EmptyID(t *testing.T) {
+	client := sendgrid.NewClient("api-key", "http://localhost", "")
+
+	_, reqErr := client.ReadDomainAuthentication(context.Background(), "")
+
+	if reqErr.Err == nil {
+		t.Fatal("ReadDomainAuthentication() expected error for empty ID, got nil")
+	}
+}
+
 func TestClient_ValidateDomainAuthentication_ShouldNotErrorForOkResponseCode(t *testing.T) {
 	teardown := setup()
 	defer teardown()
@@ -158,6 +211,37 @@ func TestClient_ValidateDomainAuthentication_ShouldErrorForErrorResponseCode(t *
 
 	if requestError.Err == nil {
 		t.Errorf("ValidateDomainAuthentication() got = %v, want %v", requestError, "error")
+	}
+}
+
+func TestClient_ValidateDomainAuthentication_ShouldErrorForNon200WithoutHTTPError(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+	mux.HandleFunc("/whitelabel/domains/123/validate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// 201 Created is not expected for validation — should be treated as error
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	client := sendgrid.NewClient("api-key", server.URL, "on-behalf")
+
+	requestError := client.ValidateDomainAuthentication(context.TODO(), "123")
+
+	if requestError.Err == nil {
+		t.Error("ValidateDomainAuthentication() expected error for non-200 status, got nil")
+	}
+	if requestError.StatusCode != http.StatusCreated {
+		t.Errorf("ValidateDomainAuthentication() StatusCode = %d, want %d", requestError.StatusCode, http.StatusCreated)
+	}
+}
+
+func TestClient_ValidateDomainAuthentication_EmptyID(t *testing.T) {
+	client := sendgrid.NewClient("api-key", "http://localhost", "")
+
+	requestError := client.ValidateDomainAuthentication(context.Background(), "")
+
+	if requestError.Err == nil {
+		t.Fatal("ValidateDomainAuthentication() expected error for empty ID, got nil")
 	}
 }
 

--- a/sendgrid/resource_sendgrid_domain_authentication_validation.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation.go
@@ -13,9 +13,9 @@ package sendgrid
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"net/http"
 
-	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -77,16 +77,12 @@ func validateDomain(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		return diag.FromErr(validateErr.Err)
 	}
 
-	if err := d.Set("valid", true); err != nil {
-		return diag.FromErr(err)
-	}
-
 	d.SetId(domainID)
 
-	return nil
+	return resourceSendgridDomainAuthenticationValidationRead(ctx, d, m)
 }
 
-func resourceSendgridDomainAuthenticationValidationRead( //nolint:funlen,cyclop
+func resourceSendgridDomainAuthenticationValidationRead(
 	ctx context.Context,
 	d *schema.ResourceData,
 	m interface{},
@@ -99,25 +95,23 @@ func resourceSendgridDomainAuthenticationValidationRead( //nolint:funlen,cyclop
 		c.OnBehalfOf = onBehalfOf
 	}
 
-	domainID := d.Get("domain_authentication_id").(string)
-	if d.Id() != "" {
-		domainID = d.Id()
-	}
+	domainID := d.Id()
 
-	if _, err := c.ReadDomainAuthentication(ctx, domainID); err.Err != nil {
+	auth, err := c.ReadDomainAuthentication(ctx, domainID)
+	if err.Err != nil {
+		if err.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return diag.FromErr(err.Err)
 	}
 
-	validateErr := c.ValidateDomainAuthentication(ctx, domainID)
-	if validateErr.Err != nil && !errors.Is(validateErr.Err, sendgrid.ErrDomainAuthenticationValidationFailed) {
-		return diag.FromErr(validateErr.Err)
-	}
+	//nolint:errcheck
+	d.Set("domain_authentication_id", fmt.Sprint(auth.ID))
+	//nolint:errcheck
+	d.Set("valid", auth.Valid)
 
-	if err := d.Set("valid", validateErr.Err == nil); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(domainID)
 	return nil
 }
 

--- a/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
@@ -28,6 +28,13 @@ func TestAccSendgridDomainAuthenticationValidationBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("sendgrid_domain_authentication.test", "automatic_security", "false"),
 				),
 			},
+			// Import test
+			{
+				ResourceName:            "sendgrid_domain_authentication_validation.this",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"sub_user_on_behalf_of"},
+			},
 		},
 	})
 }

--- a/sendgrid/resource_sendgrid_domain_authentication_validation_unit_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation_unit_test.go
@@ -14,7 +14,7 @@ func setupMockServer(handler http.Handler) (*httptest.Server, *Config) {
 	server := httptest.NewServer(handler)
 	config := &Config{
 		APIKey: "test-api-key",
-		Host:   server.URL + "/",
+		Host:   server.URL,
 	}
 
 	return server, config

--- a/sendgrid/resource_sendgrid_domain_authentication_validation_unit_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation_unit_test.go
@@ -1,0 +1,209 @@
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func setupMockServer(handler http.Handler) (*httptest.Server, *Config) {
+	server := httptest.NewServer(handler)
+	config := &Config{
+		APIKey: "test-api-key",
+		Host:   server.URL + "/",
+	}
+
+	return server, config
+}
+
+func TestDomainAuthenticationValidationRead_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whitelabel/domains/123", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":123,"domain":"example.com","valid":true}`))
+	})
+
+	server, config := setupMockServer(mux)
+	defer server.Close()
+
+	r := resourceSendgridDomainAuthenticationValidation()
+	d := r.TestResourceData()
+	d.SetId("123")
+	_ = d.Set("domain_authentication_id", "123")
+
+	diags := resourceSendgridDomainAuthenticationValidationRead(context.Background(), d, config)
+
+	if diags.HasError() {
+		t.Fatalf("Read() returned unexpected error: %v", diags)
+	}
+	if d.Get("valid") != true {
+		t.Errorf("Read() valid = %v, want true", d.Get("valid"))
+	}
+	if d.Get("domain_authentication_id") != "123" {
+		t.Errorf("Read() domain_authentication_id = %v, want '123'", d.Get("domain_authentication_id"))
+	}
+}
+
+func TestDomainAuthenticationValidationRead_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whitelabel/domains/999", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"not found"}]}`))
+	})
+
+	server, config := setupMockServer(mux)
+	defer server.Close()
+
+	r := resourceSendgridDomainAuthenticationValidation()
+	d := r.TestResourceData()
+	d.SetId("999")
+	_ = d.Set("domain_authentication_id", "999")
+
+	diags := resourceSendgridDomainAuthenticationValidationRead(context.Background(), d, config)
+
+	if diags.HasError() {
+		t.Fatalf("Read() should not return error for 404, got: %v", diags)
+	}
+	if d.Id() != "" {
+		t.Errorf("Read() should clear ID on 404, got: %s", d.Id())
+	}
+}
+
+func TestDomainAuthenticationValidationRead_WithOnBehalfOf(t *testing.T) {
+	var receivedOnBehalfOf string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whitelabel/domains/123", func(w http.ResponseWriter, r *http.Request) {
+		receivedOnBehalfOf = r.Header.Get("on-behalf-of")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":123,"domain":"example.com","valid":false}`))
+	})
+
+	server, config := setupMockServer(mux)
+	defer server.Close()
+
+	r := resourceSendgridDomainAuthenticationValidation()
+	d := r.TestResourceData()
+	d.SetId("123")
+	_ = d.Set("domain_authentication_id", "123")
+	_ = d.Set("sub_user_on_behalf_of", "test-subuser")
+
+	diags := resourceSendgridDomainAuthenticationValidationRead(context.Background(), d, config)
+
+	if diags.HasError() {
+		t.Fatalf("Read() returned unexpected error: %v", diags)
+	}
+	if receivedOnBehalfOf != "test-subuser" {
+		t.Errorf("Read() on-behalf-of header = %q, want %q", receivedOnBehalfOf, "test-subuser")
+	}
+	if d.Get("valid") != false {
+		t.Errorf("Read() valid = %v, want false", d.Get("valid"))
+	}
+}
+
+func TestDomainAuthenticationValidationCreate_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whitelabel/domains/456/validate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("validate expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":456,"valid":true}`))
+	})
+	mux.HandleFunc("/whitelabel/domains/456", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":456,"domain":"example.com","valid":true}`))
+	})
+
+	server, config := setupMockServer(mux)
+	defer server.Close()
+
+	r := resourceSendgridDomainAuthenticationValidation()
+	d := r.TestResourceData()
+	_ = d.Set("domain_authentication_id", "456")
+
+	diags := resourceSendgridDomainAuthenticationValidationCreate(context.Background(), d, config)
+
+	if diags.HasError() {
+		t.Fatalf("Create() returned unexpected error: %v", diags)
+	}
+	if d.Id() != "456" {
+		t.Errorf("Create() ID = %q, want %q", d.Id(), "456")
+	}
+	if d.Get("valid") != true {
+		t.Errorf("Create() valid = %v, want true", d.Get("valid"))
+	}
+}
+
+func TestDomainAuthenticationValidationCreate_ValidationFailed(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whitelabel/domains/456/validate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":456,"valid":false,"validation_results":{"mail_cname":{"valid":false}}}`))
+	})
+
+	server, config := setupMockServer(mux)
+	defer server.Close()
+
+	r := resourceSendgridDomainAuthenticationValidation()
+	d := r.TestResourceData()
+	_ = d.Set("domain_authentication_id", "456")
+
+	diags := resourceSendgridDomainAuthenticationValidationCreate(context.Background(), d, config)
+
+	if !diags.HasError() {
+		t.Fatal("Create() expected error when validation fails, got nil")
+	}
+}
+
+func TestDomainAuthenticationValidationDelete(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	diags := resourceSendgridDomainAuthenticationValidationDelete(context.Background(), d, nil)
+
+	if diags != nil {
+		t.Errorf("Delete() = %v, want nil", diags)
+	}
+}
+
+func TestDomainAuthenticationValidationResourceSchema(t *testing.T) {
+	r := resourceSendgridDomainAuthenticationValidation()
+
+	tests := []struct {
+		field    string
+		required bool
+		forceNew bool
+	}{
+		{"domain_authentication_id", true, true},
+		{"sub_user_on_behalf_of", false, true},
+		{"valid", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("schema_%s", tt.field), func(t *testing.T) {
+			s, ok := r.Schema[tt.field]
+			if !ok {
+				t.Fatalf("schema missing field %q", tt.field)
+			}
+			if s.Required != tt.required {
+				t.Errorf("%s Required = %v, want %v", tt.field, s.Required, tt.required)
+			}
+			if s.ForceNew != tt.forceNew {
+				t.Errorf("%s ForceNew = %v, want %v", tt.field, s.ForceNew, tt.forceNew)
+			}
+		})
+	}
+
+	if r.Schema["valid"].Computed != true {
+		t.Error("valid field should be Computed")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #92 (`fix panic error. streamline logging`). Addresses correctness issues found during code review:

- **Read no longer triggers POST on every plan/refresh** — was calling `ValidateDomainAuthentication` (POST) during Read, causing side effects on every `terraform plan`. Now uses `ReadDomainAuthentication` (GET) and reads `auth.Valid` field
- **Import now works correctly** — Read sets `domain_authentication_id` in state, previously missing after import causing perpetual diff/recreation
- **404 handling in Read** — removes resource from state when domain no longer exists, matching pattern used by other resources
- **Create calls Read at end** — restores Terraform provider convention of syncing state from API after create
- **SDK: `ReadDomainAuthentication` preserves real HTTP status code** — was hardcoding `http.StatusInternalServerError`, masking actual status (same fix as PR #85 for parse webhook)
- **SDK: `ValidateDomainAuthentication` no longer silently succeeds on non-200** — previously when `err == nil && statusCode != 200`, returned `RequestError{Err: nil}` which callers treated as success
- **Removed stale `//nolint:funlen,cyclop`** on the now-compact Read function

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All existing SDK unit tests pass
- [x] All existing provider unit tests pass
- [x] New SDK tests: `ReadDomainAuthentication` (success, 404, empty ID)
- [x] New SDK tests: `ValidateDomainAuthentication` (non-200 without HTTP error, empty ID)
- [x] New acceptance test step: import state verification for domain authentication validation
- [ ] Acceptance tests with real SendGrid account