### PR TITLE
fix(teammate): subuser_access permission_type is admin|restricted, not restricted|full

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -154,11 +154,11 @@ resource "sendgrid_teammate" "developers" {
 Required:
 
 - `id` (Number) Numeric subuser account ID.
-- `permission_type` (String) Permission level for this subuser: "restricted" (use scopes) or "full".
+- `permission_type` (String) Permission level for this subuser: "admin" (full access) or "restricted" (limited to scopes). Per the SendGrid API these are the only two values.
 
 Optional:
 
-- `scopes` (Set of String) Scopes granted on this subuser. Required when permission_type is "restricted"; ignored for "full".
+- `scopes` (Set of String) Scopes granted on this subuser. Required when permission_type is "restricted"; ignored for "admin".
 
 ## Import
 

--- a/sendgrid/resource_sendgrid_teammate.go
+++ b/sendgrid/resource_sendgrid_teammate.go
@@ -411,13 +411,13 @@ func resourceSendgridTeammate() *schema.Resource {
 						"permission_type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"restricted", "full"}, false),
-							Description:  `Permission level for this subuser: "restricted" (use scopes) or "full".`,
+							ValidateFunc: validation.StringInSlice([]string{"admin", "restricted"}, false),
+							Description:  `Permission level for this subuser: "admin" (full access) or "restricted" (limited to scopes). Per the SendGrid API these are the only two values.`,
 						},
 						"scopes": {
 							Type:        schema.TypeSet,
 							Optional:    true,
-							Description: "Scopes granted on this subuser. Required when permission_type is \"restricted\"; ignored for \"full\".",
+							Description: "Scopes granted on this subuser. Required when permission_type is \"restricted\"; ignored for \"admin\".",
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 					},
@@ -711,9 +711,9 @@ func resourceSendgridTeammateRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 // flattenSubuserAccess converts the API read response into the schema shape.
-// Scopes are only meaningful for "restricted" entries; for "full" the API may
-// echo scopes that cannot be managed, so they are dropped to avoid a perpetual
-// diff. Automatic scopes are stripped for the same reason as top-level scopes.
+// Scopes are only meaningful for "restricted" entries; for "admin" (full access)
+// the API may echo scopes that cannot be managed, so they are dropped to avoid a
+// perpetual diff. Automatic scopes are stripped as for top-level scopes.
 func flattenSubuserAccess(entries []sendgrid.SubuserAccessRead) []map[string]interface{} {
 	out := make([]map[string]interface{}, 0, len(entries))
 	for _, entry := range entries {

--- a/sendgrid/resource_sendgrid_teammate_unit_test.go
+++ b/sendgrid/resource_sendgrid_teammate_unit_test.go
@@ -154,7 +154,7 @@ func TestTeammateRead_SubuserAccess(t *testing.T) {
 			"has_restricted_subuser_access": true,
 			"subuser_access": [
 				{"id": 111, "permission_type": "restricted", "scopes": ["mail.send", "2fa_required"]},
-				{"id": 222, "permission_type": "full", "scopes": ["mail.send"]}
+				{"id": 222, "permission_type": "admin", "scopes": ["mail.send"]}
 			]
 		}`))
 	})
@@ -184,8 +184,8 @@ func TestTeammateRead_SubuserAccess(t *testing.T) {
 	if rScopes.Len() != 1 || !rScopes.Contains("mail.send") {
 		t.Errorf("restricted scopes = %v, want [mail.send] (automatic scope stripped)", rScopes.List())
 	}
-	if fScopes := byID[222]["scopes"].(*schema.Set); fScopes.Len() != 0 {
-		t.Errorf("full entry scopes = %v, want empty (dropped)", fScopes.List())
+	if aScopes := byID[222]["scopes"].(*schema.Set); aScopes.Len() != 0 {
+		t.Errorf("admin entry scopes = %v, want empty (dropped)", aScopes.List())
 	}
 }
 
@@ -217,7 +217,7 @@ func TestTeammateRead_SubuserAccessErrorPropagates(t *testing.T) {
 func TestFlattenSubuserAccess(t *testing.T) {
 	in := []sendgrid.SubuserAccessRead{
 		{ID: 1, PermissionType: "restricted", Scopes: []string{"mail.send", "2fa_exempt"}},
-		{ID: 2, PermissionType: "full", Scopes: []string{"mail.send"}},
+		{ID: 2, PermissionType: "admin", Scopes: []string{"mail.send"}},
 	}
 	out := flattenSubuserAccess(in)
 	if len(out) != 2 {
@@ -227,7 +227,7 @@ func TestFlattenSubuserAccess(t *testing.T) {
 		t.Errorf("restricted scopes = %v, want [mail.send]", got)
 	}
 	if got := out[1]["scopes"].([]string); len(got) != 0 {
-		t.Errorf("full scopes = %v, want empty", got)
+		t.Errorf("admin scopes = %v, want empty", got)
 	}
 }
 
@@ -272,11 +272,17 @@ func TestTeammatePermissionTypeValidation(t *testing.T) {
 	if vf == nil {
 		t.Fatal("permission_type should have a ValidateFunc")
 	}
-	if _, errs := vf("restricted", "permission_type"); len(errs) != 0 {
-		t.Errorf("'restricted' should be valid, got %v", errs)
+	// Per the SendGrid API, permission_type is either "admin" or "restricted".
+	for _, valid := range []string{"admin", "restricted"} {
+		if _, errs := vf(valid, "permission_type"); len(errs) != 0 {
+			t.Errorf("%q should be valid, got %v", valid, errs)
+		}
 	}
-	if _, errs := vf("typo", "permission_type"); len(errs) == 0 {
-		t.Error("'typo' should be rejected at plan time")
+	// "full" is not a real API value and must be rejected; so must typos.
+	for _, invalid := range []string{"full", "typo"} {
+		if _, errs := vf(invalid, "permission_type"); len(errs) == 0 {
+			t.Errorf("%q should be rejected at plan time", invalid)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #101. While rolling that feature out against a production account I hit a plan-time validation error that turned out to be a bug in the enum I introduced in #101 — apologies for the miss.

## The bug

The `subuser_access.permission_type` validator landed as:

```go
ValidateFunc: validation.StringInSlice([]string{"restricted", "full"}, false),
```

That set is wrong in both directions:

- **`admin` is missing**, and it's a real, documented value. A teammate granted full access to a subuser has `permission_type = "admin"`. The validator rejects it at plan time, so **any teammate with admin-level subuser access cannot be managed at all** — `terraform plan` fails before it can apply. I hit this on real teammates.
- **`full` is not a valid value.** It was my guess in #101; the API never uses or accepts it.

## Why `{admin, restricted}` is correct

The value is constrained by the SendGrid API to exactly two options, confirmed across every authoritative source:

1. **The provider's own referenced OpenAPI spec** (`tsg_teammates_v3`) defines the `PermissionType` schema with an explicit enum:
   ```json
   { "type": "string", "enum": ["admin", "restricted"] }
   ```
   and the field description: *"This property value may be either `admin` or `restricted`. When ... set to `restricted`, the Teammate has only the permissions assigned in the `scopes` property."* `"full"` does not appear anywhere in the spec.
2. **SendGrid API reference** — [Get Teammate Subuser Access](https://www.twilio.com/docs/sendgrid/api-reference/teammates/get-teammate-subuser-access) and the [SSO Teammate Permissions for a Subuser](https://support.sendgrid.com/hc/en-us/articles/27274820796059-Twilio-SendGrid-SSO-Teammate-Permissions-for-a-Subuser) article: "either `admin` or `restricted`."
3. **Live API** — real subuser_access entries come back as `admin` and `restricted`; never `full`.

## Change

- Correct the enum to `validation.StringInSlice([]string{"admin", "restricted"}, false)`.
- Update the `permission_type` and `scopes` field descriptions (scopes apply to `restricted`; `admin` is full access).
- Update the `flattenSubuserAccess` comment accordingly (scopes are dropped for `admin` entries, unchanged behaviour).
- Tests assert `admin` and `restricted` are accepted and `full` is rejected.
- Docs regenerated.

```
go build ./... && go vet ./... && go test ./...   # all green
```

No other behaviour changes; this only widens/corrects the accepted value set to match the API.