### PR TITLE
fix(teammate): persist is_sso to state in Read

### DIFF
--- a/sendgrid/resource_sendgrid_teammate.go
+++ b/sendgrid/resource_sendgrid_teammate.go
@@ -682,13 +682,16 @@ func resourceSendgridTeammateRead(ctx context.Context, d *schema.ResourceData, m
 		d.Set("last_name", teammate.LastName),
 		d.Set("scopes", filteredScopes),
 		d.Set("is_admin", teammate.IsAdmin),
+		d.Set("is_sso", teammate.IsSSO),
 		d.Set("user_status", userStatus),
 	)
 	if retErr.ErrorOrNil() != nil {
 		return diag.FromErr(retErr.ErrorOrNil())
 	}
 
-	// Read subuser_access for active SSO teammates.
+	// Read subuser_access for active SSO teammates. is_sso was just set from the
+	// API above, so d.Get reflects the current value (not stale state), which
+	// also lets freshly-imported SSO teammates populate subuser_access.
 	isSSO := d.Get("is_sso").(bool)
 	if isSSO && userStatus == "active" {
 		saResp, saErr := client.ReadSubuserAccess(ctx, email)

--- a/sendgrid/resource_sendgrid_teammate_unit_test.go
+++ b/sendgrid/resource_sendgrid_teammate_unit_test.go
@@ -144,7 +144,7 @@ func TestTeammateRead_SubuserAccess(t *testing.T) {
 		http.NotFound(w, r)
 	})
 	mux.HandleFunc("/teammates/jdoe", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"username":"jdoe","email":"jdoe@example.com","is_admin":false,"user_type":"teammate"}`))
+		_, _ = w.Write([]byte(`{"username":"jdoe","email":"jdoe@example.com","is_admin":false,"is_sso":true,"user_type":"teammate"}`))
 	})
 	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
 		// restricted entry echoes an automatic scope (must be stripped); full entry
@@ -195,7 +195,7 @@ func TestTeammateRead_SubuserAccessErrorPropagates(t *testing.T) {
 		_, _ = w.Write([]byte(`{"result":[{"username":"jdoe","email":"jdoe@example.com"}]}`))
 	})
 	mux.HandleFunc("/teammates/jdoe", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"username":"jdoe","email":"jdoe@example.com","is_admin":false,"user_type":"teammate"}`))
+		_, _ = w.Write([]byte(`{"username":"jdoe","email":"jdoe@example.com","is_admin":false,"is_sso":true,"user_type":"teammate"}`))
 	})
 	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Problem

`resourceSendgridTeammateRead` sets every field the API returns **except `is_sso`**. It only *reads* `is_sso` via `d.Get(...)` to decide whether to fetch `subuser_access`:

```go
retErr := multierror.Append(
    d.Set("email", teammate.Email),
    d.Set("username", teammate.Username),
    d.Set("first_name", teammate.FirstName),
    d.Set("last_name", teammate.LastName),
    d.Set("scopes", filteredScopes),
    d.Set("is_admin", teammate.IsAdmin),
    d.Set("user_status", userStatus),
)
...
isSSO := d.Get("is_sso").(bool)   // read, never written
```

Because the importer is `ImportStatePassthroughContext` (sets the ID only) and `is_sso` is `Required` (not `Computed`), **imported teammates land with `is_sso` null in state and never recover on refresh**, since Read never writes it back.

### Two consequences

1. **`is_sso` is null in state for every imported teammate** → spurious diffs and manual `terraform state` repair.
2. **`subuser_access` is gated behind `d.Get("is_sso")`.** With `is_sso` stale-false after import, the block is skipped, so `subuser_access` is never refreshed from the API for SSO teammates that define it.

## Fix

The data is already available — the SDK `User` struct carries `IsSSO bool \`json:"is_sso"\`` and `GET /v3/teammates/{username}` returns `is_sso`. Read simply discarded it. This adds the missing `d.Set`:

```go
d.Set("is_admin", teammate.IsAdmin),
d.Set("is_sso", teammate.IsSSO),
d.Set("user_status", userStatus),
```

Placing it **before** the `d.Get("is_sso")` gate is intended so the gate reflects the fresh API value (terraform-plugin-sdk v2 set-then-get), which should also let freshly-imported SSO teammates populate `subuser_access` on the first read. This matches the existing comment on the block: *"Always set all fields that API returns, regardless of user type."*

## Testing

- `go build ./...` and `go vet ./sendgrid/` pass.
- Confirmed the value is available at the source: a live `GET /v3/teammates/{username}` returns `is_sso`, and the SDK `User` struct already unmarshals it into `IsSSO`.
- The existing acceptance tests assert `is_sso = "false"` for the non-SSO test teammates they create; since the API returns `false` for those, this change stays consistent with them. **Acceptance tests require `TF_ACC` + live credentials and were not run for this PR.**
- The `subuser_access`-on-import improvement relies on SDK v2 set-then-get semantics and has **not** been exercised through a full import→plan cycle here; reviewers may want to confirm that path.