### PR TITLE
fix(teammate): treat self-service credential scopes as SendGrid-automatic to stop perpetual plan drift

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -4,7 +4,7 @@ subcategory: ""
 description: |-
   Manages a SendGrid teammate. Teammates are team members who have access to your SendGrid account with specific permissions.
   Important Notes:
-  Admin teammates have full access and don't need scopesScopes '2fa_exempt' and '2fa_required' are set automatically by SendGridSome scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)Use timeouts for better reliability with rate limiting
+  Admin teammates have full access and don't need scopesScopes '2fa_exempt' and '2fa_required' are set automatically by SendGridSelf-service credential scopes (user.password., user.multifactor_authentication., user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manuallySome scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)Use timeouts for better reliability with rate limiting
 ---
 
 # sendgrid_teammate (Resource)
@@ -14,6 +14,7 @@ Manages a SendGrid teammate. Teammates are team members who have access to your 
 **Important Notes:**
 - Admin teammates have full access and don't need scopes
 - Scopes '2fa_exempt' and '2fa_required' are set automatically by SendGrid
+- Self-service credential scopes (user.password.*, user.multifactor_authentication.*, user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manually
 - Some scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)
 - Use timeouts for better reliability with rate limiting
 

--- a/sendgrid/resource_sendgrid_teammate.go
+++ b/sendgrid/resource_sendgrid_teammate.go
@@ -301,6 +301,17 @@ var sendgridAutomaticScopes = map[string]bool{
 	"2fa_exempt":                 true,
 	"2fa_required":               true,
 	"sender_verification_legacy": true, // SendGrid manages this scope automatically
+	// Self-service credential scopes: SendGrid grants these automatically to
+	// password-login teammates so they can manage their own credentials, and
+	// rejects them when supplied via the teammates API.
+	"user.email.update":                      true,
+	"user.multifactor_authentication.create": true,
+	"user.multifactor_authentication.delete": true,
+	"user.multifactor_authentication.read":   true,
+	"user.multifactor_authentication.update": true,
+	"user.password.read":                     true,
+	"user.password.update":                   true,
+	"user.username.update":                   true,
 }
 
 func resourceSendgridTeammate() *schema.Resource {
@@ -310,6 +321,7 @@ func resourceSendgridTeammate() *schema.Resource {
 **Important Notes:**
 - Admin teammates have full access and don't need scopes
 - Scopes '2fa_exempt' and '2fa_required' are set automatically by SendGrid
+- Self-service credential scopes (user.password.*, user.multifactor_authentication.*, user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manually
 - Some scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)
 - Use timeouts for better reliability with rate limiting`,
 

--- a/sendgrid/validate_scopes_test.go
+++ b/sendgrid/validate_scopes_test.go
@@ -38,6 +38,12 @@ func TestValidateTeammateScopes(t *testing.T) {
 			errorContains: "set automatically by SendGrid",
 		},
 		{
+			name:          "automatic self-service credential scope",
+			scopes:        []interface{}{"mail.send", "user.password.read"},
+			expectErrors:  true,
+			errorContains: "set automatically by SendGrid",
+		},
+		{
 			name:          "mix of valid and invalid",
 			scopes:        []interface{}{"mail.send", "invalid.scope", "templates.read"},
 			expectErrors:  true,
@@ -115,6 +121,22 @@ func TestSanitizeScopes(t *testing.T) {
 			name:     "only automatic scopes",
 			input:    []string{"2fa_exempt", "2fa_required"},
 			expected: []string{},
+		},
+		{
+			name: "with self-service credential scopes",
+			input: []string{
+				"mail.send",
+				"user.email.update",
+				"user.multifactor_authentication.create",
+				"user.multifactor_authentication.delete",
+				"user.multifactor_authentication.read",
+				"user.multifactor_authentication.update",
+				"user.password.read",
+				"user.password.update",
+				"user.username.update",
+				"templates.read",
+			},
+			expected: []string{"mail.send", "templates.read"},
 		},
 	}
 


### PR DESCRIPTION
## Problem

SendGrid automatically grants eight self-service credential scopes to password-login (non-SSO) teammates so they can manage their own credentials:

- `user.email.update`
- `user.multifactor_authentication.create` / `.delete` / `.read` / `.update`
- `user.password.read` / `.update`
- `user.username.update`

The teammates API **rejects these scopes when supplied on create/update**, but **returns them on read**. Since they are not in `sendgridAutomaticScopes`, every `terraform refresh` reads them back into state, and every plan shows a perpetual in-place update trying to remove them:

```
~ resource "sendgrid_teammate" "this" {
      id     = "user@example.com"
    ~ scopes = [
        - "user.email.update",
        - "user.multifactor_authentication.create",
        ...
      ]
  }
```

Applying never converges — SendGrid keeps the scopes, so the same diff reappears on the next plan. They also can't be added to config to match reality, because provider validation rejects them as "not valid or assignable".

This is the same class of behavior already handled for `2fa_exempt`, `2fa_required`, and `sender_verification_legacy`.

## Fix

Add the eight scopes to `sendgridAutomaticScopes`, so that:

- `resourceSendgridTeammateRead` filters them out of state (eliminates the perpetual drift)
- `sanitizeScopes` strips them before any write
- `validateTeammateScopes` reports them as "set automatically by SendGrid" instead of the misleading "not valid or assignable"

Also updates the resource description and generated docs, and adds unit test cases for validation and sanitization of the new scopes.

## Testing

- `go build ./...`, `go vet ./sendgrid/`, and `go test ./...` pass
- New cases in `TestValidateTeammateScopes` and `TestSanitizeScopes` cover the added scopes
- Reproduced against a live SendGrid account: prior to this change, 10 password-login teammates showed the 8-scope removal diff on every plan; the scopes cannot be removed or assigned via the API
