### PR TITLE
fix(teammate): stop user.profile.update from re-planning forever

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -4,7 +4,7 @@ subcategory: ""
 description: |-
   Manages a SendGrid teammate. Teammates are team members who have access to your SendGrid account with specific permissions.
   Important Notes:
-  Admin teammates have full access and don't need scopesScopes '2fa_exempt' and '2fa_required' are set automatically by SendGridSelf-service credential scopes (user.password., user.multifactor_authentication., user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manuallySome scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)Use timeouts for better reliability with rate limiting
+  Admin teammates have full access and don't need scopesScopes '2fa_exempt' and '2fa_required' are set automatically by SendGridSelf-service credential scopes (user.password., user.multifactor_authentication., user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manually`user.profile.update` is accepted on write and then omitted from the next read, so Terraform can never converge on it: it is rejected in configuration, stripped from writes, and filtered out of stateSome scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)Use timeouts for better reliability with rate limiting
 ---
 
 # sendgrid_teammate (Resource)
@@ -15,6 +15,7 @@ Manages a SendGrid teammate. Teammates are team members who have access to your 
 - Admin teammates have full access and don't need scopes
 - Scopes '2fa_exempt' and '2fa_required' are set automatically by SendGrid
 - Self-service credential scopes (user.password.*, user.multifactor_authentication.*, user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manually
+- `user.profile.update` is accepted on write and then omitted from the next read, so Terraform can never converge on it: it is rejected in configuration, stripped from writes, and filtered out of state
 - Some scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)
 - Use timeouts for better reliability with rate limiting
 

--- a/sendgrid/data_source_test.go
+++ b/sendgrid/data_source_test.go
@@ -13,8 +13,8 @@ func TestAccDataSourceSendgridTeammate(t *testing.T) {
 	scopes := []string{"mail.send", "marketing.read"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSendgridTeammateConfig(email, scopes),
@@ -32,8 +32,8 @@ func TestAccDataSourceSendgridTemplate(t *testing.T) {
 	templateName := "terraform-template-data-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSendgridTemplateConfig(templateName),
@@ -52,8 +52,8 @@ func TestAccDataSourceSendgridUnsubscribeGroup(t *testing.T) {
 	description := "Test unsubscribe group for data source"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSendgridUnsubscribeGroupConfig(name, description),
@@ -72,8 +72,8 @@ func TestAccDataSourceSendgridTemplateVersion(t *testing.T) {
 	versionName := "terraform-version-data-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSendgridTemplateVersionConfig(templateName, versionName),

--- a/sendgrid/integration_test.go
+++ b/sendgrid/integration_test.go
@@ -17,8 +17,8 @@ func TestAccSendgridIntegrationEmailWorkflow(t *testing.T) {
 	unsubscribeName := "terraform-unsubscribe-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSendgridIntegrationEmailWorkflowConfig(
@@ -53,8 +53,8 @@ func TestAccSendgridIntegrationRateLimitingStress(t *testing.T) {
 	prefix := "terraform-stress-" + acctest.RandString(8)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSendgridIntegrationRateLimitingStressConfig(prefix),
@@ -83,8 +83,8 @@ func TestAccSendgridIntegrationDomainSetup(t *testing.T) {
 	linkDomain := "links-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSendgridIntegrationDomainSetupConfig(domain, linkDomain),

--- a/sendgrid/provider_test.go
+++ b/sendgrid/provider_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var testAccProviders map[string]*schema.Provider
+var testAccProviderFactories map[string]func() (*schema.Provider, error)
 
 var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = sendgrid.Provider()
-	testAccProviders = map[string]*schema.Provider{
-		"sendgrid": testAccProvider,
+	testAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"sendgrid": func() (*schema.Provider, error) { return testAccProvider, nil },
 	}
 }
 

--- a/sendgrid/rate_limiting_test.go
+++ b/sendgrid/rate_limiting_test.go
@@ -48,8 +48,8 @@ output "api_key_ids" {
 		"sendgrid_api_key.rate_test_0.id, sendgrid_api_key.rate_test_1.id, sendgrid_api_key.rate_test_2.id, sendgrid_api_key.rate_test_3.id, sendgrid_api_key.rate_test_4.id")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -108,8 +108,8 @@ resource "sendgrid_template" "rate_test_2" {
 `, templates[0], templates[1], templates[2])
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -172,8 +172,8 @@ resource "sendgrid_teammate" "rate_test_2" {
 `, emails[0], emails[1], emails[2])
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/sendgrid/resource_sendgrid_api_key_test.go
+++ b/sendgrid/resource_sendgrid_api_key_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridAPIKeyBasic(t *testing.T) {
 	scopes := []string{"mail.send", "sender_verification_eligible"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridAPIKeyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridAPIKeyConfigBasic(name, scopes),
@@ -84,9 +84,9 @@ func TestAccSendgridAPIKeyOnBehalfOf(t *testing.T) {
 	keyName := "terraform-api-key-onbehalf-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridAPIKeyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridAPIKeyConfigOnBehalfOf(username, email, password, keyName),

--- a/sendgrid/resource_sendgrid_domain_authentication_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_test.go
@@ -15,9 +15,9 @@ func TestAccSendgridDomainAuthenticationBasic(t *testing.T) {
 	domain := "test-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridDomainAuthenticationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridDomainAuthenticationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridDomainAuthenticationConfigBasic(domain),
@@ -37,9 +37,9 @@ func TestAccSendgridDomainAuthenticationCustomIPs(t *testing.T) {
 	customIPs := []string{"192.168.1.1", "192.168.1.2"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridDomainAuthenticationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridDomainAuthenticationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridDomainAuthenticationConfigCustomIPs(domain, customIPs),
@@ -57,9 +57,9 @@ func TestAccSendgridDomainAuthenticationWithRateLimiting(t *testing.T) {
 	domain := "rate-limit-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridDomainAuthenticationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridDomainAuthenticationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridDomainAuthenticationConfigWithTimeouts(domain),
@@ -162,9 +162,9 @@ func TestAccCheckSendgridDomainAuthenticationOnBehalfOf(t *testing.T) {
 	password := "TerraformTest123!"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridDomainAuthenticationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridDomainAuthenticationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridDomainAuthenticationConfigOnBehalfOf(username, email, password, domain),

--- a/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation_test.go
@@ -15,9 +15,9 @@ func TestAccSendgridDomainAuthenticationValidationBasic(t *testing.T) {
 	domain := "test-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridDomainAuthenticationValidationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridDomainAuthenticationValidationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridDomainAuthenticationValidationConfigBasic(domain),

--- a/sendgrid/resource_sendgrid_event_webhook_test.go
+++ b/sendgrid/resource_sendgrid_event_webhook_test.go
@@ -15,9 +15,9 @@ func TestAccSendgridEventWebhookBasic(t *testing.T) {
 	url := "https://example-" + acctest.RandString(10) + ".com/webhook"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigBasic(url),
@@ -43,9 +43,9 @@ func TestAccSendgridEventWebhookWithEvents(t *testing.T) {
 	url := "https://events-" + acctest.RandString(10) + ".com/webhook"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigWithEvents(url),
@@ -67,9 +67,9 @@ func TestAccSendgridEventWebhookUpdate(t *testing.T) {
 	urlUpdated := "https://updated-" + acctest.RandString(10) + ".com/webhook"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigBasic(url),
@@ -93,9 +93,9 @@ func TestAccSendgridEventWebhookWithRateLimiting(t *testing.T) {
 	url := "https://rate-limit-" + acctest.RandString(10) + ".com/webhook"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigWithTimeouts(url),
@@ -113,9 +113,9 @@ func TestAccSendgridEventWebhookWithFriendlyName(t *testing.T) {
 	friendlyName := "Test Webhook " + acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigWithFriendlyName(url, friendlyName),
@@ -136,9 +136,9 @@ func TestAccSendgridEventWebhookFriendlyNameUpdate(t *testing.T) {
 	friendlyNameUpdated := "Updated Name " + acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigWithFriendlyName(url, friendlyName),
@@ -163,9 +163,9 @@ func TestAccSendgridEventWebhookMultiple(t *testing.T) {
 	urlProd := "https://prod-" + acctest.RandString(10) + ".com/webhook"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridEventWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridEventWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridEventWebhookConfigMultiple(urlDev, urlProd),

--- a/sendgrid/resource_sendgrid_link_branding_test.go
+++ b/sendgrid/resource_sendgrid_link_branding_test.go
@@ -15,9 +15,9 @@ func TestAccSendgridLinkBrandingBasic(t *testing.T) {
 	domain := "links-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridLinkBrandingDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridLinkBrandingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridLinkBrandingConfigBasic(domain),
@@ -36,9 +36,9 @@ func TestAccSendgridLinkBrandingWithSubdomain(t *testing.T) {
 	subdomain := "mail"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridLinkBrandingDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridLinkBrandingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridLinkBrandingConfigWithSubdomain(domain, subdomain),
@@ -58,9 +58,9 @@ func TestAccSendgridLinkBrandingUpdate(t *testing.T) {
 	domainUpdated := "links-updated-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridLinkBrandingDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridLinkBrandingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridLinkBrandingConfigBasic(domain),
@@ -84,9 +84,9 @@ func TestAccSendgridLinkBrandingWithRateLimiting(t *testing.T) {
 	domain := "links-rate-limit-" + acctest.RandString(10) + ".example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridLinkBrandingDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridLinkBrandingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridLinkBrandingConfigWithTimeouts(domain),

--- a/sendgrid/resource_sendgrid_parse_webhook_test.go
+++ b/sendgrid/resource_sendgrid_parse_webhook_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridParseWebhookBasic(t *testing.T) {
 	url := "https://example-" + acctest.RandString(10) + ".com/parse"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigBasic(hostname, url),
@@ -44,9 +44,9 @@ func TestAccSendgridParseWebhookWithSendRaw(t *testing.T) {
 	url := "https://raw-" + acctest.RandString(10) + ".com/parse"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigWithSendRaw(hostname, url),
@@ -68,9 +68,9 @@ func TestAccSendgridParseWebhookUpdate(t *testing.T) {
 	urlUpdated := "https://updated-" + acctest.RandString(10) + ".com/parse"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigBasic(hostname, url),
@@ -95,9 +95,9 @@ func TestAccSendgridParseWebhookUpdateInPlace(t *testing.T) {
 	url := "https://inplace-" + acctest.RandString(10) + ".com/parse"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigBasic(hostname, url),
@@ -126,9 +126,9 @@ func TestAccSendgridParseWebhookWithRateLimiting(t *testing.T) {
 	url := "https://rate-limit-" + acctest.RandString(10) + ".com/parse"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigWithTimeouts(hostname, url),
@@ -147,9 +147,9 @@ func TestAccSendgridParseWebhookWithSecurityPolicy(t *testing.T) {
 	policyId := acctest.RandString(32)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridParseWebhookDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridParseWebhookDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridParseWebhookConfigWithWebhookSecurityPolicy(hostname, url, policyId),

--- a/sendgrid/resource_sendgrid_sso_certificate_test.go
+++ b/sendgrid/resource_sendgrid_sso_certificate_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridSSOCertificateBasic(t *testing.T) {
 	certificate := generateTestCertificate()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOCertificateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOCertificateConfigBasic(integrationId, certificate),
@@ -37,9 +37,9 @@ func TestAccSendgridSSOCertificateEnabled(t *testing.T) {
 	certificate := generateTestCertificate()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOCertificateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOCertificateConfigEnabled(integrationId, certificate),
@@ -58,9 +58,9 @@ func TestAccSendgridSSOCertificateUpdate(t *testing.T) {
 	certificate := generateTestCertificate()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOCertificateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOCertificateConfigBasic(integrationId, certificate),
@@ -85,9 +85,9 @@ func TestAccSendgridSSOCertificateWithRateLimiting(t *testing.T) {
 	certificate := generateTestCertificate()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOCertificateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOCertificateConfigWithTimeouts(integrationId, certificate),

--- a/sendgrid/resource_sendgrid_sso_integration_test.go
+++ b/sendgrid/resource_sendgrid_sso_integration_test.go
@@ -18,9 +18,9 @@ func TestAccSendgridSSOIntegrationBasic(t *testing.T) {
 	signoutURL := "https://sso-" + acctest.RandString(10) + ".example.com/logout"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOIntegrationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOIntegrationConfigBasic(name, issuer, signonURL, signoutURL),
@@ -44,9 +44,9 @@ func TestAccSendgridSSOIntegrationEnabled(t *testing.T) {
 	signoutURL := "https://sso-enabled-" + acctest.RandString(10) + ".example.com/logout"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOIntegrationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOIntegrationConfigEnabled(name, issuer, signonURL, signoutURL),
@@ -68,9 +68,9 @@ func TestAccSendgridSSOIntegrationUpdate(t *testing.T) {
 	signoutURL := "https://sso-update-" + acctest.RandString(10) + ".example.com/logout"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOIntegrationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOIntegrationConfigBasic(name, issuer, signonURL, signoutURL),
@@ -97,9 +97,9 @@ func TestAccSendgridSSOIntegrationWithRateLimiting(t *testing.T) {
 	signoutURL := "https://sso-rate-" + acctest.RandString(10) + ".example.com/logout"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSSOIntegrationDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSSOIntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSSOIntegrationConfigWithTimeouts(name, issuer, signonURL, signoutURL),

--- a/sendgrid/resource_sendgrid_subuser_test.go
+++ b/sendgrid/resource_sendgrid_subuser_test.go
@@ -17,9 +17,9 @@ func TestAccSendgridSubuserBasic(t *testing.T) {
 	password := "TerraformTest123!"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSubuserDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSubuserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSubuserConfigBasic(username, email, password),
@@ -40,9 +40,9 @@ func TestAccSendgridSubuserWithIps(t *testing.T) {
 	password := "TerraformTest123!"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSubuserDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSubuserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSubuserConfigWithIps(username, email, password),
@@ -63,9 +63,9 @@ func TestAccSendgridSubuserUpdate(t *testing.T) {
 	password := "TerraformTest123!"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSubuserDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSubuserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSubuserConfigBasic(username, email, password),
@@ -91,9 +91,9 @@ func TestAccSendgridSubuserWithRateLimiting(t *testing.T) {
 	password := "TerraformTest123!"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridSubuserDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridSubuserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridSubuserConfigWithTimeouts(username, email, password),

--- a/sendgrid/resource_sendgrid_teammate.go
+++ b/sendgrid/resource_sendgrid_teammate.go
@@ -263,7 +263,6 @@ var validSendgridScopes = map[string]bool{
 	"user.profile.create":                       true,
 	"user.profile.delete":                       true,
 	"user.profile.read":                         true,
-	"user.profile.update":                       true,
 	"user.scheduled_sends.create":               true,
 	"user.scheduled_sends.delete":               true,
 	"user.scheduled_sends.read":                 true,
@@ -311,7 +310,11 @@ var sendgridAutomaticScopes = map[string]bool{
 	"user.multifactor_authentication.update": true,
 	"user.password.read":                     true,
 	"user.password.update":                   true,
-	"user.username.update":                   true,
+	// user.profile.update is not granted automatically: SendGrid accepts it on a
+	// write and echoes it back, then omits it from the next read, so state can
+	// never converge on it. Verified against the live teammates API.
+	"user.profile.update":  true,
+	"user.username.update": true,
 }
 
 func resourceSendgridTeammate() *schema.Resource {
@@ -322,6 +325,7 @@ func resourceSendgridTeammate() *schema.Resource {
 - Admin teammates have full access and don't need scopes
 - Scopes '2fa_exempt' and '2fa_required' are set automatically by SendGrid
 - Self-service credential scopes (user.password.*, user.multifactor_authentication.*, user.email.update, user.username.update) are granted automatically by SendGrid to password-login teammates and cannot be assigned manually
+- 'user.profile.update' is accepted on write and then omitted from the next read, so Terraform can never converge on it: it is rejected in configuration, stripped from writes, and filtered out of state
 - Some scopes require specific SendGrid plans (Pro+, Marketing plans, etc.)
 - Use timeouts for better reliability with rate limiting`,
 
@@ -467,7 +471,8 @@ func validateTeammateScopes(v interface{}, path cty.Path) diag.Diagnostics {
 			Severity: diag.Error,
 			Summary:  "Automatic scopes cannot be manually assigned",
 			Detail: fmt.Sprintf(
-				"the following scopes are set automatically by SendGrid and cannot be manually assigned: %s",
+				"the following scopes are set automatically by SendGrid and cannot be manually assigned "+
+					"(some are accepted on write and then silently discarded on read): %s",
 				strings.Join(automaticScopes, ", "),
 			),
 			AttributePath: path,
@@ -500,6 +505,54 @@ func sanitizeScopes(scopes []string) []string {
 	return sanitized
 }
 
+// unpersistedScopes returns the scopes that were sent to SendGrid but are missing
+// from the follow-up read. SendGrid accepts and even echoes some scopes in the
+// write response, then drops them silently, which surfaces as a scope diff that
+// every plan re-adds and no apply can converge.
+func unpersistedScopes(d *schema.ResourceData, requested []string) []string {
+	// Admins track no scopes, and a pending teammate reports none until the
+	// invitation is accepted, so neither says anything about what was dropped.
+	if d.Get("is_admin").(bool) || d.Get("user_status").(string) == "pending" {
+		return nil
+	}
+
+	persisted := make(map[string]bool)
+	for _, s := range d.Get("scopes").(*schema.Set).List() {
+		persisted[s.(string)] = true
+	}
+
+	var dropped []string
+	for _, s := range requested {
+		if !persisted[s] {
+			dropped = append(dropped, s)
+		}
+	}
+	sort.Strings(dropped)
+
+	return dropped
+}
+
+// warnUnpersistedScopes turns dropped scopes into one actionable warning, so the
+// next time SendGrid changes what it accepts the operator learns which scope to
+// remove instead of watching an identical diff replan forever.
+func warnUnpersistedScopes(d *schema.ResourceData, requested []string) diag.Diagnostics {
+	dropped := unpersistedScopes(d, requested)
+	if len(dropped) == 0 {
+		return nil
+	}
+
+	return diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  "SendGrid did not persist some teammate scopes",
+		Detail: fmt.Sprintf(
+			"SendGrid accepted the request for %s but did not return these scopes on the following read: %s. "+
+				"Terraform will plan to add them again on every run until they are removed from the configuration. "+
+				"SendGrid changes which scopes are assignable without notice; please report the scopes listed here so the provider can filter them.",
+			d.Id(), strings.Join(dropped, ", ")),
+		AttributePath: cty.GetAttrPath("scopes"),
+	}}
+}
+
 // suppressDiffForPendingUsers suppresses diff for fields that are not available for pending users
 func suppressDiffForPendingUsers(k, old, new string, d *schema.ResourceData) bool {
 	userStatus := d.Get("user_status").(string)
@@ -521,6 +574,26 @@ func suppressDiffForPendingUsers(k, old, new string, d *schema.ResourceData) boo
 	return false
 }
 
+// validateSubuserAccessScopes applies the scope rules to subuser_access blocks
+// that the top-level scopes attribute already gets. Without it an automatic or
+// invalid scope inside a block is written, dropped again on read, and re-planned
+// on every run with nothing telling the operator why.
+func validateSubuserAccessScopes(d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+	path := cty.GetAttrPath("subuser_access")
+
+	for _, item := range d.Get("subuser_access").(*schema.Set).List() {
+		m := item.(map[string]interface{})
+		scopes, ok := m["scopes"].(*schema.Set)
+		if !ok || scopes.Len() == 0 {
+			continue
+		}
+		diags = append(diags, validateTeammateScopes(scopes, path)...)
+	}
+
+	return diags
+}
+
 // extractSubuserAccess converts the TypeSet value from the schema into the SDK slice.
 func extractSubuserAccess(d *schema.ResourceData) []sendgrid.SubuserAccess {
 	raw := d.Get("subuser_access").(*schema.Set).List()
@@ -539,6 +612,9 @@ func extractSubuserAccess(d *schema.ResourceData) []sendgrid.SubuserAccess {
 			for _, s := range scopesRaw.(*schema.Set).List() {
 				entry.Scopes = append(entry.Scopes, s.(string))
 			}
+			// flattenSubuserAccess sanitizes on read, so the write has to drop the
+			// same scopes or the block re-plans them forever.
+			entry.Scopes = sanitizeScopes(entry.Scopes)
 		}
 		out = append(out, entry)
 	}
@@ -588,6 +664,10 @@ func resourceSendgridTeammateCreate(ctx context.Context, d *schema.ResourceData,
 		if diags := validateTeammateScopes(scopesSet, path); diags.HasError() {
 			return diags
 		}
+	}
+
+	if diags := validateSubuserAccessScopes(d); diags.HasError() {
+		return diags
 	}
 
 	var scopes []string
@@ -642,7 +722,12 @@ func resourceSendgridTeammateCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	return resourceSendgridTeammateRead(ctx, d, meta)
+	diags := resourceSendgridTeammateRead(ctx, d, meta)
+	if diags.HasError() {
+		return diags
+	}
+
+	return append(diags, warnUnpersistedScopes(d, scopes)...)
 }
 
 func resourceSendgridTeammateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -774,6 +859,10 @@ func resourceSendgridTeammateUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	if diags := validateSubuserAccessScopes(d); diags.HasError() {
+		return diags
+	}
+
 	var scopes []string
 	if !isAdmin {
 		scopesList := scopesSet.List()
@@ -796,7 +885,12 @@ func resourceSendgridTeammateUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	return resourceSendgridTeammateRead(ctx, d, meta)
+	diags := resourceSendgridTeammateRead(ctx, d, meta)
+	if diags.HasError() {
+		return diags
+	}
+
+	return append(diags, warnUnpersistedScopes(d, scopes)...)
 }
 
 func resourceSendgridTeammateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/sendgrid/resource_sendgrid_teammate_test.go
+++ b/sendgrid/resource_sendgrid_teammate_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridTeammate_basic(t *testing.T) {
 	email := "terraform-test-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTeammateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTeammateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTeammateConfigBasic(email),
@@ -37,9 +37,9 @@ func TestAccSendgridTeammate_admin(t *testing.T) {
 	email := "terraform-admin-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTeammateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTeammateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTeammateConfigAdmin(email),
@@ -57,9 +57,9 @@ func TestAccSendgridTeammate_withValidScopes(t *testing.T) {
 	email := "terraform-scopes-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTeammateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTeammateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTeammateConfigWithScopes(email),
@@ -78,8 +78,8 @@ func TestAccSendgridTeammate_invalidScopes(t *testing.T) {
 	email := "terraform-invalid-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckSendgridTeammateConfigInvalidScopes(email),
@@ -93,8 +93,8 @@ func TestAccSendgridTeammate_automaticScopes(t *testing.T) {
 	email := "terraform-auto-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckSendgridTeammateConfigAutomaticScopes(email),
@@ -108,9 +108,9 @@ func TestAccSendgridTeammatePendingUser(t *testing.T) {
 	email := "terraform-teammate-pending-test-" + acctest.RandString(10) + "@example.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTeammateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTeammateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTeammateConfigBasic(email),

--- a/sendgrid/resource_sendgrid_teammate_unit_test.go
+++ b/sendgrid/resource_sendgrid_teammate_unit_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
 	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -317,5 +320,142 @@ func TestTeammateResourceSchema(t *testing.T) {
 
 	if r.Importer == nil {
 		t.Error("resource should have an Importer configured")
+	}
+}
+
+func TestUnpersistedScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		isAdmin    bool
+		userStatus string
+		persisted  []string
+		requested  []string
+		want       []string
+	}{
+		{
+			name:       "scope dropped by sendgrid",
+			userStatus: "active",
+			persisted:  []string{"mail.send"},
+			requested:  []string{"mail.send", "user.profile.update"},
+			want:       []string{"user.profile.update"},
+		},
+		{
+			name:       "every scope persisted",
+			userStatus: "active",
+			persisted:  []string{"mail.send", "templates.read"},
+			requested:  []string{"templates.read", "mail.send"},
+			want:       nil,
+		},
+		{
+			name:       "pending teammate reports no scopes yet",
+			userStatus: "pending",
+			requested:  []string{"mail.send"},
+			want:       nil,
+		},
+		{
+			name:       "admin teammate tracks no scopes",
+			isAdmin:    true,
+			userStatus: "active",
+			requested:  []string{"mail.send"},
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := resourceSendgridTeammate().TestResourceData()
+			d.SetId("jdoe@example.com")
+			if err := d.Set("is_admin", tt.isAdmin); err != nil {
+				t.Fatalf("set is_admin: %v", err)
+			}
+			if err := d.Set("user_status", tt.userStatus); err != nil {
+				t.Fatalf("set user_status: %v", err)
+			}
+			if err := d.Set("scopes", tt.persisted); err != nil {
+				t.Fatalf("set scopes: %v", err)
+			}
+
+			if got := unpersistedScopes(d, tt.requested); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("unpersistedScopes() = %v, want %v", got, tt.want)
+			}
+
+			diags := warnUnpersistedScopes(d, tt.requested)
+			if len(tt.want) == 0 {
+				if len(diags) != 0 {
+					t.Fatalf("warnUnpersistedScopes() = %v, want no diagnostics", diags)
+				}
+				return
+			}
+			if len(diags) != 1 || diags[0].Severity != diag.Warning {
+				t.Fatalf("warnUnpersistedScopes() = %v, want one warning", diags)
+			}
+			if !strings.Contains(diags[0].Detail, tt.want[0]) {
+				t.Errorf("warning detail %q does not name %q", diags[0].Detail, tt.want[0])
+			}
+		})
+	}
+}
+
+func TestSubuserAccessScopePolicy(t *testing.T) {
+	block := func(scopes []string) []interface{} {
+		return []interface{}{map[string]interface{}{
+			"id":              1,
+			"permission_type": "restricted",
+			"scopes":          scopes,
+		}}
+	}
+
+	tests := []struct {
+		name        string
+		scopes      []string
+		wantErr     bool
+		wantWritten []string
+	}{
+		{
+			name:        "automatic scope in a block is rejected and never written",
+			scopes:      []string{"mail.send", "user.profile.update"},
+			wantErr:     true,
+			wantWritten: []string{"mail.send"},
+		},
+		{
+			name:        "ordinary scopes pass and are written unchanged",
+			scopes:      []string{"mail.send", "templates.read"},
+			wantErr:     false,
+			wantWritten: []string{"mail.send", "templates.read"},
+		},
+		{
+			name:        "block without scopes is not validated",
+			scopes:      nil,
+			wantErr:     false,
+			wantWritten: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := resourceSendgridTeammate().TestResourceData()
+			if err := d.Set("subuser_access", block(tt.scopes)); err != nil {
+				t.Fatalf("set subuser_access: %v", err)
+			}
+
+			diags := validateSubuserAccessScopes(d)
+			if got := diags.HasError(); got != tt.wantErr {
+				t.Fatalf("validateSubuserAccessScopes() error = %v (%v), want %v", got, diags, tt.wantErr)
+			}
+
+			// The write payload must drop exactly what flattenSubuserAccess drops on
+			// read, or the block re-plans forever.
+			entries := extractSubuserAccess(d)
+			if len(entries) != 1 {
+				t.Fatalf("extractSubuserAccess() returned %d entries, want 1", len(entries))
+			}
+			written := append([]string(nil), entries[0].Scopes...)
+			sort.Strings(written)
+			want := append([]string(nil), tt.wantWritten...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(written, want) {
+				t.Errorf("written scopes = %v, want %v", written, want)
+			}
+		})
 	}
 }

--- a/sendgrid/resource_sendgrid_template_test.go
+++ b/sendgrid/resource_sendgrid_template_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridTemplateBasic(t *testing.T) {
 	generation := "dynamic"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTemplateDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTemplateConfigBasic(name, generation),

--- a/sendgrid/resource_sendgrid_template_version_test.go
+++ b/sendgrid/resource_sendgrid_template_version_test.go
@@ -17,9 +17,9 @@ func TestAccSendgridTemplateVersionBasic(t *testing.T) {
 	subject := "terraform-subject-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridTemplateVersionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridTemplateVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridTemplateVersionConfigBasic(

--- a/sendgrid/resource_sendgrid_unsubscribe_group_test.go
+++ b/sendgrid/resource_sendgrid_unsubscribe_group_test.go
@@ -16,9 +16,9 @@ func TestAccSendgridUnsubscribeGroupBasic(t *testing.T) {
 	description := "Test unsubscribe group created by Terraform"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridUnsubscribeGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridUnsubscribeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridUnsubscribeGroupConfigBasic(name, description),
@@ -40,9 +40,9 @@ func TestAccSendgridUnsubscribeGroupUpdate(t *testing.T) {
 	descriptionUpdated := "Updated test unsubscribe group"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridUnsubscribeGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridUnsubscribeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridUnsubscribeGroupConfigBasic(name, description),
@@ -69,9 +69,9 @@ func TestAccSendgridUnsubscribeGroupWithRateLimiting(t *testing.T) {
 	description := "Test unsubscribe group with rate limiting"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridUnsubscribeGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridUnsubscribeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridUnsubscribeGroupConfigWithTimeouts(name, description),

--- a/sendgrid/resource_sendgrid_webhook_security_policy_test.go
+++ b/sendgrid/resource_sendgrid_webhook_security_policy_test.go
@@ -18,9 +18,9 @@ func TestAccSendgridWebhookSecurityPolicyOidcOnly(t *testing.T) {
 	name := "OIDC Only Policy" + acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridWebhookSecurityPolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridWebhookSecurityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridWebhookSecurityPolicyOidcOnly(name, client_id, client_secret, token_url),
@@ -82,9 +82,9 @@ func TestAccSendgridWebhookSecurityPolicySignatureOnly(t *testing.T) {
 	name := "Signature Only Policy" + acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridWebhookSecurityPolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridWebhookSecurityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridWebhookSecurityPolicySignatureOnly(name),
@@ -140,9 +140,9 @@ func TestAccSendgridWebhookSecurityPolicyOidcAndSignature(t *testing.T) {
 	name := "OIDC and Signature Policy" + acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridWebhookSecurityPolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridWebhookSecurityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridWebhookSecurityPolicySignatureAndOidc(name, client_id, client_secret, token_url),
@@ -185,9 +185,9 @@ func TestAccSendgridWebhookSecurityPolicyUpdate(t *testing.T) {
 	nameUpdated := "Updated Signature Policy " + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSendgridWebhookSecurityPolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckSendgridWebhookSecurityPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckSendgridWebhookSecurityPolicySignatureUpdate(name),

--- a/sendgrid/validate_scopes_test.go
+++ b/sendgrid/validate_scopes_test.go
@@ -44,6 +44,12 @@ func TestValidateTeammateScopes(t *testing.T) {
 			errorContains: "set automatically by SendGrid",
 		},
 		{
+			name:          "automatic profile update scope",
+			scopes:        []interface{}{"mail.send", "user.profile.update"},
+			expectErrors:  true,
+			errorContains: "set automatically by SendGrid",
+		},
+		{
 			name:          "mix of valid and invalid",
 			scopes:        []interface{}{"mail.send", "invalid.scope", "templates.read"},
 			expectErrors:  true,
@@ -134,6 +140,7 @@ func TestSanitizeScopes(t *testing.T) {
 				"user.password.read",
 				"user.password.update",
 				"user.username.update",
+				"user.profile.update",
 				"templates.read",
 			},
 			expected: []string{"mail.send", "templates.read"},


### PR DESCRIPTION
## Description

`user.profile.update` made `sendgrid_teammate` unconvergeable. Verified against the live teammates API:

- `PATCH /v3/teammates/{username}` with the scope returns `200` and **echoes the scope back** in the response body.
- The very next `GET /v3/teammates/{username}` does **not** list it.

So Terraform wrote the scope, read state back without it, and re-added it on every plan. Confirmed in the field on a 128-scope teammate set: the plan reported `127 unchanged elements hidden` and re-added exactly one scope, forever.

This is the same class as #116 / `54125a4` (`user.password.*`, `user.email.update`, `user.username.update`, `user.multifactor_authentication.*`), with one difference: those scopes were never in `validSendgridScopes`, so that fix only changed a message. This one was in both maps, so it used to validate and apply.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (dependency updates, tooling, etc.)

## Changes Made

**1. Classify the scope (`sendgridAutomaticScopes`).** Validation rejects it, `sanitizeScopes` drops it from writes, `Read` filters it out of state. Also removed the duplicate entry from `validSendgridScopes` -- it was the only scope present in both maps; the other eleven automatic scopes are absent from `validSendgridScopes`.

**2. Say what was verified, not what was assumed.** The existing self-service wording ("granted automatically by SendGrid to password-login teammates") does not describe this scope -- it was observed on SSO teammates, and the behavior is accept-then-discard, not auto-grant. The scope gets its own line in the docs and the resource Description, and the validator detail now ends `(some are accepted on write and then silently discarded on read)`. The `set automatically by SendGrid and cannot be manually assigned` substring is unchanged, so existing assertions still hold.

**3. Generic read-back detector (the part that matters next time).** `unpersistedScopes` / `warnUnpersistedScopes`, wired into Create and Update: compare the scopes sent with what the follow-up `Read` returned and emit **one warning** naming anything SendGrid dropped. Admin teammates (no tracked scopes) and pending teammates (no scopes until the invite is accepted) are skipped to avoid false positives. Warning, not error -- erroring after a successful write would strand the teammate. The point is that the next silently-dropped scope costs one apply to diagnose instead of an infinite diff.

**4. Same scope rules for `subuser_access` blocks.** `flattenSubuserAccess` already ran block scopes through `sanitizeScopes` on read, while `extractSubuserAccess` wrote them verbatim, and `validateTeammateScopes` only ever saw the root `scopes` set. An automatic scope inside a block therefore reproduced this exact non-converging diff one level down. Block scopes are now sanitized on write and validated in Create/Update.

## Testing

### Unit Tests

- [x] I have added unit tests for my changes
- [x] All unit tests pass locally (`go test ./...`)

- `TestUnpersistedScopes` -- dropped scope is named; all-persisted, pending, and admin cases produce no warning.
- `TestSubuserAccessScopePolicy` -- an automatic scope in a block is rejected and never reaches the write payload; ordinary block scopes pass through unchanged; a block without scopes is not validated.
- `TestValidateTeammateScopes` / `TestSanitizeScopes` extended with the new scope.

`make fmt` clean. `golangci-lint run ./sendgrid/...` reports only 3 pre-existing `SA1019` deprecation hits in `data_source_test.go`, untouched by this PR.

### Manual Testing

The write/read asymmetry was reproduced directly against a production SendGrid account (PATCH echoes the scope at index 114, subsequent GET returns `null` for it) before writing the fix.

## Interaction with #114

#114 touches the same two files and the same Create/Update paths, so this will need a merge resolution -- but the changes are complementary, not competing: #114 stops **root** scopes from being sent alongside `subuser_access`, this PR makes **block** scopes obey the scope rules. Two things for whoever merges second:

1. #114's create-time placeholder is `user.profile.read`, which this PR leaves untouched and valid. Worth keeping in mind that a placeholder from the same `user.profile.*` family is one reclassification away from breaking.
2. Once both land, #114's placeholder path sends a scope the operator never configured, so the new read-back warning could name `user.profile.read` if SendGrid drops it. The detector should skip provider-injected placeholder scopes.

## Breaking Changes

**Is this a breaking change?** Yes -- a configuration listing `user.profile.update`, at the root or inside a `subuser_access` block, now fails validation and must drop the scope. In practice the scope was never actually persisted by SendGrid, so removing it changes no effective permission.

Left to the maintainer's call, deliberately not decided here: whether this ships as a minor bump with an `UPGRADING.md` entry (the convention used for v2.1.0). GoReleaser has `changelog.disable: true`, so a patch release would give consumers no signal at all.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Mozilla Public License 2.0.
