### PR TITLE
fix(sdk): read every page of a teammate's subuser access

### DIFF
--- a/sdk/teammate.go
+++ b/sdk/teammate.go
@@ -54,6 +54,19 @@ type SubuserAccessResponse struct {
 	SubuserAccess              []SubuserAccessRead `json:"subuser_access"`
 }
 
+// The subuser access listing is paginated: it returns at most `limit` entries
+// (100 when the parameter is omitted) and continues from `after_subuser_id`.
+// Every caller here needs the whole list, because a partial list is what the
+// next update would write back - the PATCH replaces subuser_access wholesale,
+// so entries missing from a truncated read would lose access.
+const (
+	subuserAccessPageLimit = 500
+
+	// Bounds the walk so a response that never advances the cursor cannot spin
+	// forever. 500 * 40 is far beyond any real teammate.
+	subuserAccessMaxPages = 40
+)
+
 // updateSSOTeammateRequest is the request body for PATCH /v3/sso/teammates/{username}.
 // We keep it separate from User to avoid polluting that struct with SSO-only fields.
 //
@@ -279,23 +292,65 @@ func (c *Client) ReadSubuserAccess(ctx context.Context, email string) (*SubuserA
 		return nil, requestErr
 	}
 
-	respBody, statusCode, err := c.Get(ctx, "GET", "/teammates/"+username+"/subuser_access")
-	if err != nil {
-		return nil, RequestError{
-			StatusCode: statusCode,
-			Err:        fmt.Errorf("failed reading subuser_access for %s: %w", email, err),
+	// Walk the pages by cursor rather than trusting a page to be short: the API
+	// may serve fewer entries than the requested limit, so "shorter than asked
+	// for" does not mean "last page". Stop on an empty page, or as soon as a page
+	// fails to advance past the cursor, which is what a server that ignores
+	// after_subuser_id looks like.
+	out := SubuserAccessResponse{}
+	after := 0
+
+	for page := 0; page < subuserAccessMaxPages; page++ {
+		endpoint := fmt.Sprintf("/teammates/%s/subuser_access?limit=%d", username, subuserAccessPageLimit)
+		if after > 0 {
+			endpoint += fmt.Sprintf("&after_subuser_id=%d", after)
 		}
+
+		respBody, statusCode, err := c.Get(ctx, "GET", endpoint)
+		if err != nil {
+			return nil, RequestError{
+				StatusCode: statusCode,
+				Err:        fmt.Errorf("failed reading subuser_access for %s: %w", email, err),
+			}
+		}
+
+		var body SubuserAccessResponse
+		if jsonErr := json.Unmarshal([]byte(respBody), &body); jsonErr != nil {
+			return nil, RequestError{
+				StatusCode: http.StatusInternalServerError,
+				Err:        fmt.Errorf("failed parsing subuser_access response: %w", jsonErr),
+			}
+		}
+
+		if page == 0 {
+			out.HasRestrictedSubuserAccess = body.HasRestrictedSubuserAccess
+		}
+
+		if len(body.SubuserAccess) == 0 {
+			break
+		}
+
+		maxID := after
+		for _, entry := range body.SubuserAccess {
+			// Skip anything at or before the cursor: a server that ignores
+			// after_subuser_id repeats the first page, and repeats must not
+			// become duplicate entries.
+			if entry.ID <= after {
+				continue
+			}
+			out.SubuserAccess = append(out.SubuserAccess, entry)
+			if entry.ID > maxID {
+				maxID = entry.ID
+			}
+		}
+
+		if maxID <= after {
+			break
+		}
+		after = maxID
 	}
 
-	var body SubuserAccessResponse
-	if jsonErr := json.Unmarshal([]byte(respBody), &body); jsonErr != nil {
-		return nil, RequestError{
-			StatusCode: http.StatusInternalServerError,
-			Err:        fmt.Errorf("failed parsing subuser_access response: %w", jsonErr),
-		}
-	}
-
-	return &body, RequestError{StatusCode: http.StatusOK, Err: nil}
+	return &out, RequestError{StatusCode: http.StatusOK, Err: nil}
 }
 
 func (c *Client) DeleteUser(ctx context.Context, email string) (bool, RequestError) {

--- a/sdk/teammate.go
+++ b/sdk/teammate.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 type User struct {
@@ -55,17 +57,69 @@ type SubuserAccessResponse struct {
 }
 
 // The subuser access listing is paginated: it returns at most `limit` entries
-// (100 when the parameter is omitted) and continues from `after_subuser_id`.
-// Every caller here needs the whole list, because a partial list is what the
-// next update would write back - the PATCH replaces subuser_access wholesale,
-// so entries missing from a truncated read would lose access.
+// (100 when the parameter is omitted) and publishes the next cursor under
+// `_metadata`. Every caller here needs the whole list, because a partial list is
+// what the next update would write back - the PATCH replaces subuser_access
+// wholesale, so entries missing from a truncated read would lose access. That is
+// why this walk would rather fail than hand back an incomplete list.
 const (
 	subuserAccessPageLimit = 500
 
-	// Bounds the walk so a response that never advances the cursor cannot spin
-	// forever. 500 * 40 is far beyond any real teammate.
+	// Bounds the walk so a response that keeps producing pages cannot spin
+	// forever. Reaching it is an error, not a quiet stop.
 	subuserAccessMaxPages = 40
 )
+
+// subuserAccessCursor is an `after_subuser_id` value from a response. SendGrid
+// renders `_metadata.next_params` values as strings on some endpoints and as
+// numbers on others, so accept either rather than silently reading no cursor.
+type subuserAccessCursor int
+
+func (c *subuserAccessCursor) UnmarshalJSON(raw []byte) error {
+	text := strings.Trim(string(raw), `"`)
+	if text == "" || text == "null" {
+		return nil
+	}
+
+	value, err := strconv.Atoi(text)
+	if err != nil {
+		return fmt.Errorf("unexpected after_subuser_id %s: %w", raw, err)
+	}
+	*c = subuserAccessCursor(value)
+
+	return nil
+}
+
+// subuserAccessMetadata models the pagination cursor. The reference documents it
+// under `next_params`; accept it directly on `_metadata` as well, because the
+// same field is described both ways.
+type subuserAccessMetadata struct {
+	NextParams struct {
+		AfterSubuserID *subuserAccessCursor `json:"after_subuser_id"`
+	} `json:"next_params"`
+	AfterSubuserID *subuserAccessCursor `json:"after_subuser_id"`
+}
+
+// nextCursor reports the cursor the server published, and whether it published
+// one at all. No cursor means the server says nothing is outstanding.
+func (m subuserAccessMetadata) nextCursor() (int, bool) {
+	if m.NextParams.AfterSubuserID != nil {
+		return int(*m.NextParams.AfterSubuserID), true
+	}
+	if m.AfterSubuserID != nil {
+		return int(*m.AfterSubuserID), true
+	}
+
+	return 0, false
+}
+
+// subuserAccessPage is one response of the listing. It is separate from
+// SubuserAccessResponse, which is the aggregate this package hands back.
+type subuserAccessPage struct {
+	HasRestrictedSubuserAccess bool                  `json:"has_restricted_subuser_access"`
+	SubuserAccess              []SubuserAccessRead   `json:"subuser_access"`
+	Metadata                   subuserAccessMetadata `json:"_metadata"`
+}
 
 // updateSSOTeammateRequest is the request body for PATCH /v3/sso/teammates/{username}.
 // We keep it separate from User to avoid polluting that struct with SSO-only fields.
@@ -292,29 +346,38 @@ func (c *Client) ReadSubuserAccess(ctx context.Context, email string) (*SubuserA
 		return nil, requestErr
 	}
 
-	// Walk the pages by cursor rather than trusting a page to be short: the API
-	// may serve fewer entries than the requested limit, so "shorter than asked
-	// for" does not mean "last page". Stop on an empty page, or as soon as a page
-	// fails to advance past the cursor, which is what a server that ignores
-	// after_subuser_id looks like.
+	// Walk the pages until the server says nothing is outstanding. Anything else
+	// that ends the walk - a page that does not advance, the page budget - is an
+	// error: a partial list here becomes state, and state is what the next update
+	// writes back over the real access.
 	out := SubuserAccessResponse{}
+	seen := make(map[int]bool)
 	after := 0
+	complete := false
 
-	for page := 0; page < subuserAccessMaxPages; page++ {
+	for page := 0; page < subuserAccessMaxPages && !complete; page++ {
 		endpoint := fmt.Sprintf("/teammates/%s/subuser_access?limit=%d", username, subuserAccessPageLimit)
-		if after > 0 {
+		if page > 0 {
 			endpoint += fmt.Sprintf("&after_subuser_id=%d", after)
 		}
 
 		respBody, statusCode, err := c.Get(ctx, "GET", endpoint)
 		if err != nil {
+			// Only the first request can mean "no such teammate". Passing a later
+			// page's 404 up would tell the caller the teammate is gone, and the
+			// resource clears itself from state when it hears that.
+			status := statusCode
+			if page > 0 {
+				status = http.StatusInternalServerError
+			}
+
 			return nil, RequestError{
-				StatusCode: statusCode,
-				Err:        fmt.Errorf("failed reading subuser_access for %s: %w", email, err),
+				StatusCode: status,
+				Err:        fmt.Errorf("failed reading subuser_access for %s at cursor %d: %w", email, after, err),
 			}
 		}
 
-		var body SubuserAccessResponse
+		var body subuserAccessPage
 		if jsonErr := json.Unmarshal([]byte(respBody), &body); jsonErr != nil {
 			return nil, RequestError{
 				StatusCode: http.StatusInternalServerError,
@@ -324,30 +387,77 @@ func (c *Client) ReadSubuserAccess(ctx context.Context, email string) (*SubuserA
 
 		if page == 0 {
 			out.HasRestrictedSubuserAccess = body.HasRestrictedSubuserAccess
+
+			// Without restricted access the entry list is every subuser on the
+			// account, which says nothing about this teammate and which the caller
+			// discards. Do not page through it - and this is a finished read, not a
+			// walk that gave up.
+			if !body.HasRestrictedSubuserAccess {
+				complete = true
+				break
+			}
 		}
 
-		if len(body.SubuserAccess) == 0 {
-			break
-		}
-
+		added := 0
 		maxID := after
 		for _, entry := range body.SubuserAccess {
-			// Skip anything at or before the cursor: a server that ignores
-			// after_subuser_id repeats the first page, and repeats must not
-			// become duplicate entries.
-			if entry.ID <= after {
+			// Dedupe on the id itself rather than on the cursor: a repeated page
+			// must not become duplicate entries, and an entry the server orders
+			// after a higher id must not be dropped.
+			if seen[entry.ID] {
 				continue
 			}
+			seen[entry.ID] = true
 			out.SubuserAccess = append(out.SubuserAccess, entry)
+			added++
 			if entry.ID > maxID {
 				maxID = entry.ID
 			}
 		}
 
-		if maxID <= after {
-			break
+		next, published := body.Metadata.nextCursor()
+		full := len(body.SubuserAccess) >= subuserAccessPageLimit
+
+		switch {
+		case len(body.SubuserAccess) == 0:
+			complete = true
+		case published && next > after:
+			after = next
+		case published:
+			// A cursor that does not move is a server contradicting itself.
+			return nil, RequestError{
+				StatusCode: http.StatusInternalServerError,
+				Err: fmt.Errorf(
+					"subuser_access for %s published cursor %d at or before the current cursor %d; refusing to return a partial list",
+					email, next, after),
+			}
+		case !full:
+			// No cursor and the page was not even full: the list is finished. This
+			// is the common path, and it costs no extra request.
+			complete = true
+		case added == 0 || maxID <= after:
+			// A full page with no cursor that did not advance means the walk cannot
+			// make progress. Reporting success here would hand back exactly the
+			// truncated list this function exists to prevent.
+			return nil, RequestError{
+				StatusCode: http.StatusInternalServerError,
+				Err: fmt.Errorf(
+					"subuser_access for %s did not advance past id %d; refusing to return a partial list",
+					email, after),
+			}
+		default:
+			// A full page and no cursor: keep walking from the highest id seen.
+			after = maxID
 		}
-		after = maxID
+	}
+
+	if !complete {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err: fmt.Errorf(
+				"subuser_access for %s did not finish within %d pages; refusing to return a partial list",
+				email, subuserAccessMaxPages),
+		}
 	}
 
 	return &out, RequestError{StatusCode: http.StatusOK, Err: nil}

--- a/sdk/teammate_test.go
+++ b/sdk/teammate_test.go
@@ -141,3 +141,91 @@ func TestClient_UpdateSSOUser_SendsIsAdminWhenTrue(t *testing.T) {
 		t.Error("is_admin must be sent when true")
 	}
 }
+
+func TestClient_ReadSubuserAccess_WalksPages(t *testing.T) {
+	var seen []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.URL.RawQuery)
+		switch r.URL.Query().Get("after_subuser_id") {
+		case "":
+			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
+				{"id":111,"permission_type":"admin"},
+				{"id":222,"permission_type":"admin"}
+			]}`))
+		case "222":
+			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
+				{"id":333,"permission_type":"restricted","scopes":["mail.send"]}
+			]}`))
+		default:
+			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[]}`))
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	resp, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+	if reqErr.Err != nil {
+		t.Fatalf("ReadSubuserAccess() unexpected error: %v", reqErr.Err)
+	}
+
+	// A truncated read is what the next update would write back, so every page
+	// has to be collected.
+	if len(resp.SubuserAccess) != 3 {
+		t.Fatalf("collected %d entries across pages, want 3: %+v", len(resp.SubuserAccess), resp.SubuserAccess)
+	}
+	if resp.SubuserAccess[2].ID != 333 {
+		t.Errorf("last entry = %+v, want the id 333 from the second page", resp.SubuserAccess[2])
+	}
+	if !resp.HasRestrictedSubuserAccess {
+		t.Error("expected HasRestrictedSubuserAccess = true from the first page")
+	}
+
+	// An explicit limit on every request, and the cursor from the second one on.
+	if len(seen) != 3 {
+		t.Fatalf("made %d requests (%v), want 3: two pages plus the empty one that ends the walk", len(seen), seen)
+	}
+	if seen[0] != "limit=500" {
+		t.Errorf("first request query = %q, want limit=500 rather than the API's default of 100", seen[0])
+	}
+	if seen[1] != "limit=500&after_subuser_id=222" {
+		t.Errorf("second request query = %q, want the cursor at the highest id of the first page", seen[1])
+	}
+}
+
+func TestClient_ReadSubuserAccess_StopsWhenCursorIsIgnored(t *testing.T) {
+	requests := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	// A server that ignores after_subuser_id serves the same page forever.
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
+			{"id":111,"permission_type":"admin"}
+		]}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	resp, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+	if reqErr.Err != nil {
+		t.Fatalf("ReadSubuserAccess() unexpected error: %v", reqErr.Err)
+	}
+
+	// Stop instead of looping, and do not turn the repeated page into duplicates.
+	if requests != 2 {
+		t.Errorf("made %d requests, want 2: the walk must stop once a page fails to advance the cursor", requests)
+	}
+	if len(resp.SubuserAccess) != 1 {
+		t.Errorf("collected %d entries, want 1: a repeated page must not duplicate entries", len(resp.SubuserAccess))
+	}
+}

--- a/sdk/teammate_test.go
+++ b/sdk/teammate_test.go
@@ -3,9 +3,11 @@ package sendgrid_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	sendgrid "github.com/arslanbekov/terraform-provider-sendgrid/sdk"
@@ -142,7 +144,19 @@ func TestClient_UpdateSSOUser_SendsIsAdminWhenTrue(t *testing.T) {
 	}
 }
 
-func TestClient_ReadSubuserAccess_WalksPages(t *testing.T) {
+// fullSubuserAccessPage renders a page at the walk's own limit, so the walk sees
+// a page that could have more behind it.
+func fullSubuserAccessPage(firstID int, cursor string) string {
+	entries := make([]string, 0, 500)
+	for i := 0; i < 500; i++ {
+		entries = append(entries, fmt.Sprintf(`{"id":%d,"permission_type":"admin"}`, firstID+i))
+	}
+
+	return fmt.Sprintf(`{"has_restricted_subuser_access":true,"subuser_access":[%s]%s}`,
+		strings.Join(entries, ","), cursor)
+}
+
+func TestClient_ReadSubuserAccess_WalksPagesByPublishedCursor(t *testing.T) {
 	var seen []string
 
 	mux := http.NewServeMux()
@@ -153,16 +167,20 @@ func TestClient_ReadSubuserAccess_WalksPages(t *testing.T) {
 		seen = append(seen, r.URL.RawQuery)
 		switch r.URL.Query().Get("after_subuser_id") {
 		case "":
+			// The server says there is more, so the walk must continue even though
+			// this page is far shorter than the requested limit.
 			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
 				{"id":111,"permission_type":"admin"},
 				{"id":222,"permission_type":"admin"}
-			]}`))
+			],"_metadata":{"next_params":{"after_subuser_id":"222"}}}`))
 		case "222":
+			// No cursor: nothing is outstanding.
 			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
 				{"id":333,"permission_type":"restricted","scopes":["mail.send"]}
-			]}`))
+			],"_metadata":{"next_params":{}}}`))
 		default:
-			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[]}`))
+			t.Errorf("unexpected cursor %q", r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"subuser_access":[]}`))
 		}
 	})
 	server := httptest.NewServer(mux)
@@ -174,43 +192,37 @@ func TestClient_ReadSubuserAccess_WalksPages(t *testing.T) {
 		t.Fatalf("ReadSubuserAccess() unexpected error: %v", reqErr.Err)
 	}
 
-	// A truncated read is what the next update would write back, so every page
-	// has to be collected.
 	if len(resp.SubuserAccess) != 3 {
-		t.Fatalf("collected %d entries across pages, want 3: %+v", len(resp.SubuserAccess), resp.SubuserAccess)
+		t.Fatalf("collected %d entries, want 3: %+v", len(resp.SubuserAccess), resp.SubuserAccess)
 	}
-	if resp.SubuserAccess[2].ID != 333 {
-		t.Errorf("last entry = %+v, want the id 333 from the second page", resp.SubuserAccess[2])
-	}
-	if !resp.HasRestrictedSubuserAccess {
-		t.Error("expected HasRestrictedSubuserAccess = true from the first page")
-	}
-
-	// An explicit limit on every request, and the cursor from the second one on.
-	if len(seen) != 3 {
-		t.Fatalf("made %d requests (%v), want 3: two pages plus the empty one that ends the walk", len(seen), seen)
+	// The published cursor ends the walk, so the last page costs no extra request.
+	if len(seen) != 2 {
+		t.Fatalf("made %d requests (%v), want 2", len(seen), seen)
 	}
 	if seen[0] != "limit=500" {
 		t.Errorf("first request query = %q, want limit=500 rather than the API's default of 100", seen[0])
 	}
 	if seen[1] != "limit=500&after_subuser_id=222" {
-		t.Errorf("second request query = %q, want the cursor at the highest id of the first page", seen[1])
+		t.Errorf("second request query = %q, want the cursor the server published", seen[1])
 	}
 }
 
-func TestClient_ReadSubuserAccess_StopsWhenCursorIsIgnored(t *testing.T) {
-	requests := 0
-
+func TestClient_ReadSubuserAccess_KeepsFirstPageRestrictedFlag(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(teammateListBody))
 	})
-	// A server that ignores after_subuser_id serves the same page forever.
 	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
-			{"id":111,"permission_type":"admin"}
-		]}`))
+		if r.URL.Query().Get("after_subuser_id") == "" {
+			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
+				{"id":111,"permission_type":"admin"}
+			],"_metadata":{"next_params":{"after_subuser_id":111}}}`))
+			return
+		}
+		// A later page disagreeing about the flag must not win.
+		_, _ = w.Write([]byte(`{"has_restricted_subuser_access":false,"subuser_access":[
+			{"id":222,"permission_type":"admin"}
+		],"_metadata":{}}`))
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
@@ -220,12 +232,138 @@ func TestClient_ReadSubuserAccess_StopsWhenCursorIsIgnored(t *testing.T) {
 	if reqErr.Err != nil {
 		t.Fatalf("ReadSubuserAccess() unexpected error: %v", reqErr.Err)
 	}
-
-	// Stop instead of looping, and do not turn the repeated page into duplicates.
-	if requests != 2 {
-		t.Errorf("made %d requests, want 2: the walk must stop once a page fails to advance the cursor", requests)
+	if !resp.HasRestrictedSubuserAccess {
+		t.Error("HasRestrictedSubuserAccess = false, want the first page's true")
 	}
-	if len(resp.SubuserAccess) != 1 {
-		t.Errorf("collected %d entries, want 1: a repeated page must not duplicate entries", len(resp.SubuserAccess))
+	if len(resp.SubuserAccess) != 2 {
+		t.Errorf("collected %d entries, want 2", len(resp.SubuserAccess))
+	}
+}
+
+func TestClient_ReadSubuserAccess_SkipsPagingForUnrestrictedTeammate(t *testing.T) {
+	requests := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	// For an administrator the endpoint returns every subuser on the account; the
+	// list says nothing about this teammate, so there is nothing to page through.
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"has_restricted_subuser_access":false,"subuser_access":[
+			{"id":111,"permission_type":"admin"},
+			{"id":222,"permission_type":"admin"}
+		],"_metadata":{"next_params":{"after_subuser_id":222}}}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	resp, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+	if reqErr.Err != nil {
+		t.Fatalf("ReadSubuserAccess() unexpected error: %v", reqErr.Err)
+	}
+	if requests != 1 {
+		t.Errorf("made %d requests, want 1 - an unrestricted teammate must not be paged", requests)
+	}
+	if resp.HasRestrictedSubuserAccess {
+		t.Error("HasRestrictedSubuserAccess = true, want false")
+	}
+}
+
+func TestClient_ReadSubuserAccess_ErrorsWhenCursorDoesNotAdvance(t *testing.T) {
+	requests := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	// A server that ignores after_subuser_id serves the same full page forever.
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(fullSubuserAccessPage(1, "")))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	resp, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+
+	// A partial list must never be handed back as success: it becomes state, and
+	// the next update writes state over the real access.
+	if reqErr.Err == nil {
+		t.Fatalf("ReadSubuserAccess() succeeded with %d entries, want an error", len(resp.SubuserAccess))
+	}
+	if resp != nil {
+		t.Errorf("ReadSubuserAccess() returned a list alongside the error: %d entries", len(resp.SubuserAccess))
+	}
+	if !strings.Contains(reqErr.Err.Error(), "did not advance") {
+		t.Errorf("error = %v, want it to name the stalled cursor", reqErr.Err)
+	}
+	if requests != 2 {
+		t.Errorf("made %d requests, want 2 - the walk must stop as soon as it cannot progress", requests)
+	}
+}
+
+func TestClient_ReadSubuserAccess_ErrorsWhenPageBudgetExhausted(t *testing.T) {
+	requests := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	// Always a full page, always a fresh cursor: progress that never ends.
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		first := requests * 1000
+		cursor := fmt.Sprintf(`,"_metadata":{"next_params":{"after_subuser_id":%d}}`, first+499)
+		_, _ = w.Write([]byte(fullSubuserAccessPage(first, cursor)))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	resp, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+
+	if reqErr.Err == nil {
+		t.Fatalf("ReadSubuserAccess() succeeded with %d entries, want an error at the page budget", len(resp.SubuserAccess))
+	}
+	if !strings.Contains(reqErr.Err.Error(), "did not finish within") {
+		t.Errorf("error = %v, want it to name the page budget", reqErr.Err)
+	}
+	if requests != 40 {
+		t.Errorf("made %d requests, want the 40-page budget", requests)
+	}
+}
+
+func TestClient_ReadSubuserAccess_MidWalkFailureIsNotNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/teammates", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(teammateListBody))
+	})
+	mux.HandleFunc("/teammates/jdoe/subuser_access", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("after_subuser_id") == "" {
+			_, _ = w.Write([]byte(`{"has_restricted_subuser_access":true,"subuser_access":[
+				{"id":111,"permission_type":"admin"}
+			],"_metadata":{"next_params":{"after_subuser_id":111}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"not found"}]}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := sendgrid.NewClient("api-key", server.URL, "")
+	_, reqErr := client.ReadSubuserAccess(context.Background(), "jdoe@example.com")
+
+	if reqErr.Err == nil {
+		t.Fatal("ReadSubuserAccess() succeeded, want the mid-walk failure surfaced")
+	}
+	// The resource clears itself from state on a 404, so only the first request
+	// may report one - a missing cursor page is not a missing teammate.
+	if reqErr.StatusCode == http.StatusNotFound {
+		t.Errorf("StatusCode = 404 for a cursor page; that tells the caller the teammate is gone")
 	}
 }


### PR DESCRIPTION
## Description

`ReadSubuserAccess` requested `/v3/teammates/{username}/subuser_access` with no query parameters. That endpoint returns **100 entries by default** and paginates on `after_subuser_id` ([Get Teammate Subuser Access](https://www.twilio.com/docs/sendgrid/api-reference/teammates/get-teammate-subuser-access)), so any teammate with more subusers than one page was read back truncated. `SubuserAccessResponse` does not model `_metadata` either, so the provider could not even tell a truncated list from a complete one.

That list is not read-only data, which is what makes this more than a cosmetic diff:

- `subuser_access` is `Optional + Computed`, so a truncated read becomes state.
- The next update sends state back, and `UpdateSSOUserWithSubuserAccess` replaces `subuser_access` wholesale.
- So every subuser past the first page would **silently lose access** on an apply that was about something else entirely — a `last_name` change is enough.
- Separately, a configuration declaring more blocks than one page returned produced a plan that never converges.

Found while reviewing #114; it is older than that PR (the read path dates to `bed390e`) and independent of it, so it is fixed here on its own.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (dependency updates, tooling, etc.)

## Changes Made

Walk the pages by cursor: request an explicit `limit=500` and continue from `after_subuser_id` set to the highest id seen so far.

Two decisions worth reviewing:

1. **The walk stops on an empty page, not on a short one.** A page shorter than the requested limit does not prove it is the last page — the API is free to serve fewer entries than asked for, and treating "short" as "done" is the same silent truncation this fix removes. The cost is one extra request at the end of the walk.
2. **Two guards bound a misbehaving response.** Entries at or before the cursor are skipped, so a server that ignores `after_subuser_id` and repeats the first page cannot produce duplicate entries; and the walk ends as soon as a page fails to advance the cursor, so that same server costs two requests instead of an infinite loop. A page ceiling (`subuserAccessMaxPages`) backstops both.

`has_restricted_subuser_access` is taken from the first page, matching how the teammate resource uses it.

## Testing

### Unit Tests

- [x] I have added unit tests for my changes
- [x] All unit tests pass locally (`go test ./...`)

- `TestClient_ReadSubuserAccess_WalksPages` — two pages plus the terminating empty one: asserts all three entries are collected, that the first request carries `limit=500` rather than relying on the default of 100, and that the second carries the cursor at the highest id of the first page.
- `TestClient_ReadSubuserAccess_StopsWhenCursorIsIgnored` — a server that serves the same page forever: asserts exactly two requests and no duplicated entry.

Both were mutation-checked: deleting the cursor advance makes them fail (`collected 2 entries across pages, want 3`). `golangci-lint run ./...` reports 0 issues.

### Manual Testing

Not run against a live account — this needs a teammate with more than 100 subusers to observe, which I do not have. The behaviour is pinned by the mock-server tests above instead.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Mozilla Public License 2.0.
